### PR TITLE
DNS controller and endpoint controller for raven L7

### DIFF
--- a/config/raven-controller-manager/rbac/role.yaml
+++ b/config/raven-controller-manager/rbac/role.yaml
@@ -98,3 +98,16 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+    - ""
+  resources:
+    - pods
+    - services
+    - configmaps
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - update
+    - watch

--- a/config/raven-controller-manager/tunnel/configmap.yaml
+++ b/config/raven-controller-manager/tunnel/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: yurt-tunnel-server-cfg
+  namespace: kube-system
+data:
+  localhost-proxy-ports: "10255, 10250, 10266, 10267"
+  http-proxy-ports: "9445"
+  https-proxy-ports: "9100"

--- a/config/raven-controller-manager/tunnel/kustomization.yaml
+++ b/config/raven-controller-manager/tunnel/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- service.yaml
+- configmap.yaml

--- a/config/raven-controller-manager/tunnel/service.yaml
+++ b/config/raven-controller-manager/tunnel/service.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: x-raven-server-svc
+  namespace: kube-system
+  labels:
+    yurt-app: yurt-tunnel-server
+spec:
+  selector:
+    yurt-app: yurt-tunnel-server
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ports:
+    - name: tcp
+      port: 10262
+      targetPort: 10262
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: x-raven-server-internal-svc
+  namespace: kube-system
+  labels:
+    yurt-app: yurt-tunnel-server
+spec:
+  selector:
+    yurt-app: yurt-tunnel-server
+  ports:
+    - name: https
+      port: 10250
+      targetPort: 10263
+    - name: http
+      port: 10255
+      targetPort: 10264

--- a/config/setup/all_in_one.yaml
+++ b/config/setup/all_in_one.yaml
@@ -303,6 +303,19 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -544,3 +557,50 @@ webhooks:
         resources:
           - gateways
     sideEffects: None
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: yurt-tunnel-server-cfg
+data:
+  localhost-proxy-ports: "10255, 10250, 10266, 10267"
+  http-proxy-ports: "9445"
+  https-proxy-ports: "9100"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: raven-server-svc
+  namespace: kube-system
+  labels:
+    yurt-app: yurt-tunnel-server
+spec:
+  selector:
+    yurt-app: yurt-tunnel-server
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ports:
+    - name: tcp
+      port: 10262
+      targetPort: 10262
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: raven-server-internal-svc
+  namespace: kube-system
+  labels:
+    yurt-app: yurt-tunnel-server
+spec:
+  selector:
+    yurt-app: yurt-tunnel-server
+  ports:
+    - name: https
+      port: 10250
+      targetPort: 10263
+    - name: http
+      port: 10255
+      targetPort: 10264

--- a/hack/lib/release-images.sh
+++ b/hack/lib/release-images.sh
@@ -138,5 +138,6 @@ gen_yamls() {
     set +x
     echo "==== create raven-controller-manager.yaml in $OUT_YAML_DIR ===="
     kustomize build ${BUILD_YAML_DIR}/default > ${OUT_YAML_DIR}/raven-controller-manager.yaml
+    kustomize build ${BUILD_YAML_DIR}/tunnel > ${OUT_YAML_DIR}/raven-server-controller.yaml
     rm -Rf ${BUILD_YAML_DIR}
 }

--- a/pkg/dnscontroller/constants.go
+++ b/pkg/dnscontroller/constants.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnscontroller
+
+const (
+	RavenProxyInternalServiceName = "x-raven-server-internal-svc"
+	RavenProxyResourceNamespace   = "kube-system"
+	RavenDNSRecordNodeDataKey     = "tunnel-nodes"
+
+	RavenDNSRecordConfigMapName = "%s-tunnel-nodes"
+	RavenProxyServiceLabelKey   = "%s-app"
+	RavenProxyServiceLabelValue = "%s-tunnel-server"
+
+	RavenAgentPodLabelKey   = "app"
+	RavenAgentPodLabelValue = "raven-agent"
+
+	NodeNameKeyIndex = "spec.nodeName"
+
+	MaxRetries    = 15
+	MinSyncPeriod = 30
+)
+
+var (
+	ravenDNSRecordConfigMapName = GetRavenDNSRecordConfigMapName()
+	ravenProxyServiceLabelKey   = GetRavenProxyServiceLabelKey()
+	ravenProxyServiceLabelValue = GetRavenProxyServiceLabelValue()
+)

--- a/pkg/dnscontroller/dns_controller.go
+++ b/pkg/dnscontroller/dns_controller.go
@@ -1,0 +1,390 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnscontroller
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+// DNSRecordController interface defines the method for manage
+// the dns records of node from cloud to edge
+type DNSRecordController interface {
+	Run(stopCh <-chan struct{})
+}
+
+type dnsRecordController struct {
+	lock            sync.Mutex
+	client          clientset.Interface
+	informerFactory informers.SharedInformerFactory
+	queue           workqueue.RateLimitingInterface
+
+	dnsSharedInformer   dnsInformer
+	syncPeriod          int
+	ravenServiceIPCache string
+
+	getPodsAssignedToNode func(nodeName string) ([]*corev1.Pod, error)
+}
+
+type dnsInformer struct {
+	nodeLister corelisters.NodeLister
+	svcLister  corelisters.ServiceLister
+	podLister  corelisters.PodLister
+
+	nodeInformerSynced cache.InformerSynced
+	svcInformerSynced  cache.InformerSynced
+	podInformerSynced  cache.InformerSynced
+}
+
+// NewCoreDNSRecordController create a CoreDNSRecordController that synchronizes node dns records with CoreDNS configuration
+func NewCoreDNSRecordController(client clientset.Interface, syncPeriod int) DNSRecordController {
+	sharedInformerFactory := informers.NewSharedInformerFactory(client, 24*time.Hour)
+	RegisterInformersForDNS(sharedInformerFactory)
+
+	dc := &dnsRecordController{
+		client:          client,
+		syncPeriod:      syncPeriod,
+		informerFactory: sharedInformerFactory,
+		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "tunnel-dns"),
+	}
+
+	nodeInformerFactory := sharedInformerFactory.Core().V1().Nodes()
+	nodeInformer := nodeInformerFactory.Informer()
+	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    dc.addNode,
+		UpdateFunc: dc.updateNode,
+		DeleteFunc: dc.deleteNode,
+	})
+	dc.dnsSharedInformer.nodeLister = nodeInformerFactory.Lister()
+	dc.dnsSharedInformer.nodeInformerSynced = nodeInformer.HasSynced
+
+	svcInformerFactory := sharedInformerFactory.Core().V1().Services()
+	svcInformer := svcInformerFactory.Informer()
+	svcInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    dc.addService,
+		UpdateFunc: dc.updateService,
+		DeleteFunc: dc.deleteService,
+	})
+	dc.dnsSharedInformer.svcLister = svcInformerFactory.Lister()
+	dc.dnsSharedInformer.svcInformerSynced = svcInformer.HasSynced
+
+	podInformerFactory := sharedInformerFactory.Core().V1().Pods()
+	podInformer := podInformerFactory.Informer()
+	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    dc.addPod,
+		UpdateFunc: dc.updatePod,
+		DeleteFunc: dc.deletePod,
+	})
+	dc.dnsSharedInformer.podLister = podInformerFactory.Lister()
+	dc.dnsSharedInformer.podInformerSynced = podInformer.HasSynced
+
+	podIndexer := podInformer.GetIndexer()
+	dc.getPodsAssignedToNode = func(nodeName string) ([]*corev1.Pod, error) {
+		objs, err := podIndexer.ByIndex(NodeNameKeyIndex, nodeName)
+		if err != nil {
+			return nil, err
+		}
+		pods := make([]*corev1.Pod, 0, len(objs))
+		for _, obj := range objs {
+			pod, ok := obj.(*corev1.Pod)
+			if !ok {
+				continue
+			}
+			pods = append(pods, pod)
+		}
+		return pods, nil
+	}
+
+	// override syncPeriod when the specified value is too small
+	if dc.syncPeriod < MinSyncPeriod {
+		dc.syncPeriod = MinSyncPeriod
+	}
+
+	return dc
+}
+
+func (dc *dnsRecordController) Run(stopCh <-chan struct{}) {
+	electionChecker := leaderelection.NewLeaderHealthzAdaptor(time.Second * 30)
+	id, err := os.Hostname()
+	if err != nil {
+		klog.Fatalf("failed to get hostname, %v", err)
+	}
+	resourceLock, err := resourcelock.New("leases", metav1.NamespaceSystem, "raven-dns-controller",
+		dc.client.CoreV1(),
+		dc.client.CoordinationV1(),
+		resourcelock.ResourceLockConfig{
+			Identity: id + "_" + string(uuid.NewUUID()),
+		})
+	if err != nil {
+		klog.Fatalf("error creating raven-dns-controller resource lock, %v", err)
+	}
+	leaderelection.RunOrDie(context.Background(), leaderelection.LeaderElectionConfig{
+		Lock:          resourceLock,
+		LeaseDuration: metav1.Duration{Duration: time.Second * time.Duration(15)}.Duration,
+		RenewDeadline: metav1.Duration{Duration: time.Second * time.Duration(10)}.Duration,
+		RetryPeriod:   metav1.Duration{Duration: time.Second * time.Duration(2)}.Duration,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				klog.V(3).Infoln("raven dns controller start to running")
+				dc.run(stopCh)
+			},
+			OnStoppedLeading: func() {
+				klog.Fatalf("leader election has stopped")
+			},
+		},
+		WatchDog: electionChecker,
+		Name:     "raven-dns-controller",
+	})
+	panic("unreachable")
+}
+
+func (dc *dnsRecordController) run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer dc.queue.ShutDown()
+
+	klog.Infof("starting raven dns record controller")
+	defer klog.Infof("shutting down raven dns record controller")
+
+	dc.informerFactory.Start(stopCh)
+
+	if !cache.WaitForNamedCacheSync("raven-dns-controller", stopCh,
+		dc.dnsSharedInformer.nodeInformerSynced,
+		dc.dnsSharedInformer.svcInformerSynced,
+		dc.dnsSharedInformer.podInformerSynced) {
+		return
+	}
+
+	if err := dc.manageRavenDNSRecordConfigMap(); err != nil {
+		klog.Errorf("failed to manage dns record ConfigMap %v/%v, %v",
+			RavenProxyResourceNamespace, ravenDNSRecordConfigMapName, err)
+		return
+	}
+
+	go wait.Until(dc.worker, time.Second, stopCh)
+
+	go wait.Until(dc.syncDNSRecordAsWhole, time.Duration(dc.syncPeriod)*time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (dc *dnsRecordController) enqueue(eventType EventType, obj interface{}) {
+	ele := &Event{
+		Type: eventType,
+		Obj:  obj,
+	}
+	dc.queue.Add(ele)
+}
+
+func (dc *dnsRecordController) worker() {
+	for dc.processNextWorkItem() {
+	}
+}
+
+func (dc *dnsRecordController) processNextWorkItem() bool {
+	event, quit := dc.queue.Get()
+	if quit {
+		return false
+	}
+	defer dc.queue.Done(event)
+
+	err := dc.dispatch(event.(*Event))
+	dc.handleErr(err, event)
+	return true
+}
+
+func (dc *dnsRecordController) dispatch(event *Event) error {
+	switch event.Type {
+	case NodeAdd:
+		return dc.onAddNode(event.Obj.(*corev1.Node))
+	case NodeUpdate:
+		return dc.onUpdateNode(event.Obj.(*corev1.Node))
+	case NodeDelete:
+		return dc.onDeleteNode(event.Obj.(*corev1.Node))
+	case ServiceAdd:
+		return dc.onAddService()
+	case ServiceUpdate:
+		return dc.onUpdateService()
+	case PodAdd:
+		return dc.onAddPod(event.Obj.(*corev1.Pod))
+	case PodUpdate:
+		return dc.onUpdatePod(event.Obj.(*corev1.Pod))
+	case PodDelete:
+		return dc.onDeletePod(event.Obj.(*corev1.Pod))
+	default:
+		return nil
+	}
+}
+
+func (dc *dnsRecordController) handleErr(err error, event interface{}) {
+	if err == nil {
+		dc.queue.Forget(event)
+		return
+	}
+
+	if dc.queue.NumRequeues(event) < MaxRetries {
+		klog.Infof("error syncing event %v: %v", event, err)
+		dc.queue.AddRateLimited(event)
+		return
+	}
+	utilruntime.HandleError(err)
+	klog.Infof("dropping event %q out of the queue: %v", event, err)
+	dc.queue.Forget(event)
+}
+
+func (dc *dnsRecordController) manageRavenDNSRecordConfigMap() error {
+	_, err := dc.client.CoreV1().ConfigMaps(RavenProxyResourceNamespace).
+		Get(context.TODO(), ravenDNSRecordConfigMapName, metav1.GetOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ravenDNSRecordConfigMapName,
+				Namespace: RavenProxyResourceNamespace,
+			},
+			Data: map[string]string{
+				RavenDNSRecordNodeDataKey: "",
+			},
+		}
+		_, err = dc.client.CoreV1().ConfigMaps(RavenProxyResourceNamespace).
+			Create(context.TODO(), cm, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create ConfigMap %v/%v, %w",
+				RavenProxyResourceNamespace, ravenDNSRecordConfigMapName, err)
+		}
+	}
+	return err
+}
+
+func (dc *dnsRecordController) syncDNSRecordAsWhole() {
+	klog.V(2).Info("start sync dns record as whole")
+
+	dc.lock.Lock()
+	defer dc.lock.Unlock()
+	_, err := dc.getRavenInternalServiceIP(false)
+	if err != nil {
+		klog.Errorf("failed to sync dns record as whole, %v", err)
+		return
+	}
+
+	err = dc.updateDNSRecordsAsWhole()
+	if err != nil {
+		klog.Errorf("failed to sync dns record as whole, %v", err)
+		return
+	}
+}
+
+func (dc *dnsRecordController) getRavenInternalServiceIP(useCache bool) (string, error) {
+
+	if useCache && len(dc.ravenServiceIPCache) != 0 {
+		return dc.ravenServiceIPCache, nil
+	}
+	svc, err := dc.dnsSharedInformer.svcLister.Services(RavenProxyResourceNamespace).Get(RavenProxyInternalServiceName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get %v/%v service, %w",
+			RavenProxyResourceNamespace, RavenProxyInternalServiceName, err)
+	}
+
+	if len(svc.Spec.ClusterIP) == 0 {
+		return "", fmt.Errorf("unable find ClusterIP from %s/%s service, %w",
+			RavenProxyResourceNamespace, RavenProxyInternalServiceName, err)
+	}
+
+	dc.ravenServiceIPCache = svc.Spec.ClusterIP
+
+	return dc.ravenServiceIPCache, nil
+}
+
+func (dc *dnsRecordController) updateDNSRecordsAsWhole() (err error) {
+	// list all raven agent pod
+	pods, err := dc.dnsSharedInformer.podLister.List(labels.Everything())
+
+	if err != nil {
+		klog.Errorf("failed to sync dns record as whole, %v", err)
+	}
+	tables := make(map[string]struct{})
+	for _, pod := range pods {
+		if len(pod.Spec.NodeName) == 0 {
+			continue
+		}
+		tables[pod.Spec.NodeName] = struct{}{}
+	}
+
+	//list all node
+	nodes, err := dc.dnsSharedInformer.nodeLister.List(labels.Everything())
+
+	if err != nil {
+		klog.Errorf("failed to sync dns record as whole, %v", err)
+		return
+	}
+
+	//format dns record
+	records := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		ip, err := getNodeHostIP(node)
+		if err != nil {
+			klog.Errorf("failed to parse node address for %v, %v", node.Name, err)
+			continue
+		}
+
+		if _, ok := tables[node.Name]; ok && isEdgeNode(node) {
+			ip, err = dc.getRavenInternalServiceIP(true)
+			if err != nil {
+				klog.Errorf("failed to get service ClusterIP address for %v, %v", node.Name, err)
+				continue
+			}
+		}
+		records = append(records, formatDNSRecord(ip, node.Name))
+	}
+	sort.Strings(records)
+
+	cm, err := dc.client.CoreV1().ConfigMaps(RavenProxyResourceNamespace).
+		Get(context.TODO(), ravenDNSRecordConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get configmap %v/%v for sync dns record as whole, %v",
+			RavenProxyResourceNamespace, ravenDNSRecordConfigMapName, err)
+	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data[RavenDNSRecordNodeDataKey] = strings.Join(records, "\n")
+	if _, err := dc.client.CoreV1().ConfigMaps(RavenProxyResourceNamespace).
+		Update(context.Background(), cm, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("failed to update configmap %v/%v, %w",
+			RavenProxyResourceNamespace, ravenDNSRecordConfigMapName, err)
+	}
+	return nil
+}

--- a/pkg/dnscontroller/dns_controller_test.go
+++ b/pkg/dnscontroller/dns_controller_test.go
@@ -1,0 +1,549 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnscontroller
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	client "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const (
+	failed  = "\u2717"
+	succeed = "\u2713"
+)
+
+func newFakeDnsController(fakeClient client.Interface, nodes []*corev1.Node, pods []*corev1.Pod, services []*corev1.Service) (dc *dnsRecordController) {
+	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClient, 24*time.Hour)
+	RegisterInformersForDNS(sharedInformerFactory)
+
+	dc = &dnsRecordController{
+		client:              fakeClient,
+		syncPeriod:          60,
+		informerFactory:     sharedInformerFactory,
+		queue:               workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "tunnel-dns"),
+		ravenServiceIPCache: "172.168.0.1",
+	}
+
+	nodeInformerFactory := sharedInformerFactory.Core().V1().Nodes()
+	nodeInformer := nodeInformerFactory.Informer()
+	dc.dnsSharedInformer.nodeLister = nodeInformerFactory.Lister()
+	dc.dnsSharedInformer.nodeInformerSynced = nodeInformer.HasSynced
+
+	svcInformerFactory := sharedInformerFactory.Core().V1().Services()
+	svcInformer := svcInformerFactory.Informer()
+	dc.dnsSharedInformer.svcLister = svcInformerFactory.Lister()
+	dc.dnsSharedInformer.svcInformerSynced = svcInformer.HasSynced
+
+	podInformerFactory := sharedInformerFactory.Core().V1().Pods()
+	podInformer := podInformerFactory.Informer()
+	dc.dnsSharedInformer.podLister = podInformerFactory.Lister()
+	dc.dnsSharedInformer.podInformerSynced = podInformer.HasSynced
+
+	podIndexer := podInformer.GetIndexer()
+	nodeIndexer := nodeInformer.GetIndexer()
+	svcIndexer := svcInformer.GetIndexer()
+
+	for _, po := range pods {
+		if podIndexer.Add(po) != nil {
+			continue
+		}
+	}
+
+	for _, node := range nodes {
+		if nodeIndexer.Add(node) != nil {
+			continue
+		}
+	}
+
+	for _, svc := range services {
+		if svcIndexer.Add(svc) != nil {
+			continue
+		}
+	}
+
+	dc.getPodsAssignedToNode = func(nodeName string) ([]*corev1.Pod, error) {
+		objs, err := podIndexer.ByIndex(NodeNameKeyIndex, nodeName)
+		if err != nil {
+			return nil, err
+		}
+		pods := make([]*corev1.Pod, 0, len(objs))
+		for _, obj := range objs {
+			pod, ok := obj.(*corev1.Pod)
+			if !ok {
+				continue
+			}
+			pods = append(pods, pod)
+		}
+		return pods, nil
+	}
+
+	// override syncPeriod when the specified value is too small
+	if dc.syncPeriod < MinSyncPeriod {
+		dc.syncPeriod = MinSyncPeriod
+	}
+
+	return dc
+}
+
+func TestDnsRecordController_ManagerRavenDNSRecordConfigMap(t *testing.T) {
+	testcases := []struct {
+		desc     string
+		useCache bool
+		client   client.Interface
+		nodes    []*corev1.Node
+		pods     []*corev1.Pod
+		services []*corev1.Service
+		expect   *corev1.ConfigMap
+	}{
+		{
+			desc:     fmt.Sprintf("there is no configmap %v", ravenDNSRecordConfigMapName),
+			useCache: false,
+			client:   fake.NewSimpleClientset(),
+			nodes:    []*corev1.Node{},
+			pods:     []*corev1.Pod{},
+			services: []*corev1.Service{},
+			expect: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ravenDNSRecordConfigMapName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Data: map[string]string{
+					RavenDNSRecordNodeDataKey: "",
+				},
+			},
+		},
+		{
+			desc:     fmt.Sprintf("there is a configmap %v", ravenDNSRecordConfigMapName),
+			useCache: true,
+			client: fake.NewSimpleClientset(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenDNSRecordConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						RavenDNSRecordNodeDataKey: "",
+					},
+				}),
+			nodes:    []*corev1.Node{},
+			pods:     []*corev1.Pod{},
+			services: []*corev1.Service{},
+			expect: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ravenDNSRecordConfigMapName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Data: map[string]string{
+					RavenDNSRecordNodeDataKey: "",
+				},
+			},
+		},
+	}
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeDnsController(tt.client, tt.nodes, tt.pods, tt.services)
+			err := fakeDc.manageRavenDNSRecordConfigMap()
+			if err != nil {
+				t.Logf("failed to create configmap %v/%v", RavenProxyResourceNamespace, ravenDNSRecordConfigMapName)
+			}
+			get, _ := fakeDc.client.CoreV1().ConfigMaps(RavenProxyResourceNamespace).
+				Get(context.TODO(), ravenDNSRecordConfigMapName, metav1.GetOptions{})
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect, get)
+			}
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}
+
+func TestDnsRecordController_GetRavenProxyInternalService(t *testing.T) {
+	testcases := []struct {
+		desc     string
+		client   client.Interface
+		nodes    []*corev1.Node
+		pods     []*corev1.Pod
+		services []*corev1.Service
+		expect   string
+	}{
+		{
+			desc:   fmt.Sprintf("get service %s", RavenProxyInternalServiceName),
+			client: fake.NewSimpleClientset(),
+			nodes:  []*corev1.Node{},
+			pods:   []*corev1.Pod{},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			expect: "172.168.0.1",
+		},
+
+		{
+			desc:     fmt.Sprintf("failed to get service %s", RavenProxyInternalServiceName),
+			client:   fake.NewSimpleClientset(),
+			nodes:    []*corev1.Node{},
+			pods:     []*corev1.Pod{},
+			services: []*corev1.Service{},
+			expect:   "",
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeDnsController(tt.client, tt.nodes, tt.pods, tt.services)
+			get, err := fakeDc.getRavenInternalServiceIP(false)
+			if err != nil {
+				t.Logf("failed to get svc %s/%s", RavenProxyResourceNamespace, RavenProxyInternalServiceName)
+			}
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect, get)
+			}
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}
+
+func TestDnsRecordController_UpdateDNSRecordsAsWhole(t *testing.T) {
+	getDNSRecord := func(client client.Interface) (string, error) {
+		cm, err := client.CoreV1().ConfigMaps(RavenProxyResourceNamespace).
+			Get(context.TODO(), ravenDNSRecordConfigMapName, metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+		if cm.Data == nil {
+			cm.Data = make(map[string]string)
+		}
+		return cm.Data[RavenDNSRecordNodeDataKey], nil
+	}
+
+	testcases := []struct {
+		desc     string
+		client   client.Interface
+		nodes    []*corev1.Node
+		pods     []*corev1.Pod
+		services []*corev1.Service
+		expect   string
+	}{
+
+		{
+			desc: "there is no dns records",
+			client: fake.NewSimpleClientset(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenDNSRecordConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						RavenDNSRecordNodeDataKey: "",
+					},
+				},
+			),
+			expect: "",
+		},
+
+		{
+			desc: "update dns records as whole",
+			client: fake.NewSimpleClientset(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ravenDNSRecordConfigMapName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Data: map[string]string{
+					RavenDNSRecordNodeDataKey: "",
+				},
+			}),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cloud-node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "false",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.1",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "edge-node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.2",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "edge-node-2",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.3",
+							},
+						},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod-1",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							RavenAgentPodLabelKey: RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "cloud-node-1",
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod-2",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							RavenAgentPodLabelKey: RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "edge-node-1",
+					},
+				},
+			},
+			services: []*corev1.Service{},
+			expect:   "172.168.0.1\tedge-node-1\n192.168.0.1\tcloud-node-1\n192.168.0.3\tedge-node-2",
+		},
+	}
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeDnsController(tt.client, tt.nodes, tt.pods, tt.services)
+			err := fakeDc.updateDNSRecordsAsWhole()
+			if err != nil {
+				t.Logf("failed to update dns records as whole")
+			}
+			get, err := getDNSRecord(fakeDc.client)
+			if err != nil {
+				t.Logf("failed to get dns records")
+			}
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect, get)
+			}
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}
+
+func TestDnsRecordController_SyncDNSRecordsAsWhole(t *testing.T) {
+	getDNSRecord := func(client client.Interface) (string, error) {
+		cm, err := client.CoreV1().ConfigMaps(RavenProxyResourceNamespace).
+			Get(context.TODO(), ravenDNSRecordConfigMapName, metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+		if cm.Data == nil {
+			cm.Data = make(map[string]string)
+		}
+		return cm.Data[RavenDNSRecordNodeDataKey], nil
+	}
+
+	testcases := []struct {
+		desc     string
+		client   client.Interface
+		nodes    []*corev1.Node
+		pods     []*corev1.Pod
+		services []*corev1.Service
+		expect   string
+	}{
+
+		{
+			desc: "there is no dns records",
+			client: fake.NewSimpleClientset(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenDNSRecordConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						RavenDNSRecordNodeDataKey: "",
+					},
+				},
+			),
+			expect: "",
+		},
+
+		{
+			desc: "update dns records as whole",
+			client: fake.NewSimpleClientset(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ravenDNSRecordConfigMapName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Data: map[string]string{
+					RavenDNSRecordNodeDataKey: "",
+				},
+			}),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cloud-node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "false",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.1",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "edge-node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.2",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "edge-node-2",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.3",
+							},
+						},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod-1",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							RavenAgentPodLabelKey: RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "cloud-node-1",
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod-2",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							RavenAgentPodLabelKey: RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "edge-node-1",
+					},
+				},
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			expect: "172.168.0.1\tedge-node-1\n192.168.0.1\tcloud-node-1\n192.168.0.3\tedge-node-2",
+		},
+	}
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeDnsController(tt.client, tt.nodes, tt.pods, tt.services)
+			fakeDc.syncDNSRecordAsWhole()
+			get, err := getDNSRecord(fakeDc.client)
+			if err != nil {
+				t.Logf("failed to get dns records")
+			}
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect, get)
+			}
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}

--- a/pkg/dnscontroller/event.go
+++ b/pkg/dnscontroller/event.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnscontroller
+
+type EventType string
+
+const (
+	NodeAdd       EventType = "NODE_ADD"
+	NodeUpdate    EventType = "NODE_UPDATE"
+	NodeDelete    EventType = "NODE_DELETE"
+	ServiceAdd    EventType = "SERVICE_ADD"
+	ServiceUpdate EventType = "SERVICE_UPDATE"
+	PodAdd        EventType = "Pod_ADD"
+	PodUpdate     EventType = "Pod_UPDATE"
+	PodDelete     EventType = "Pod_DELETE"
+)
+
+type Event struct {
+	Type EventType
+	Obj  interface{}
+}

--- a/pkg/dnscontroller/handler.go
+++ b/pkg/dnscontroller/handler.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnscontroller
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+func (dc *dnsRecordController) addNode(obj interface{}) {
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		return
+	}
+	if node.DeletionTimestamp != nil {
+		dc.deleteNode(node)
+		return
+	}
+	klog.V(2).Infof("enqueue node add event for %v", node.Name)
+	dc.enqueue(NodeAdd, node)
+}
+
+func (dc *dnsRecordController) updateNode(oldObj, newObj interface{}) {
+	oldNode, ok := oldObj.(*corev1.Node)
+	if !ok {
+		return
+	}
+	newNode, ok := newObj.(*corev1.Node)
+	if !ok {
+		return
+	}
+	if isEdgeNode(oldNode) == isEdgeNode(newNode) {
+		return
+	}
+	klog.V(2).Infof("enqueue node update event for %v, will update dns record", newNode.Name)
+	dc.enqueue(NodeUpdate, newNode)
+}
+
+func (dc *dnsRecordController) deleteNode(obj interface{}) {
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("can not get object from tombstone %#v", obj))
+			return
+		}
+		node, ok = tombstone.Obj.(*corev1.Node)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object is not a node %#v", obj))
+			return
+		}
+	}
+	klog.V(2).Infof("enqueue node delete event for %v", node.Name)
+	dc.enqueue(NodeDelete, node)
+}
+
+func (dc *dnsRecordController) addService(obj interface{}) {
+	svc, ok := obj.(*corev1.Service)
+	if !ok {
+		return
+	}
+	klog.V(2).Infof("enqueue service add event for %v/%v", svc.Namespace, svc.Name)
+	dc.enqueue(ServiceAdd, svc)
+}
+
+func (dc *dnsRecordController) updateService(oldObj, newObj interface{}) {
+	oldSvc, ok := oldObj.(*corev1.Service)
+	if !ok {
+		return
+	}
+	newSvc, ok := newObj.(*corev1.Service)
+	if !ok {
+		return
+	}
+	if oldSvc.Spec.ClusterIP != newSvc.Spec.ClusterIP {
+		klog.V(2).Infof("enqueue service update event for %v/%v", newSvc.Namespace, newSvc.Name)
+		dc.enqueue(ServiceUpdate, newSvc)
+	}
+}
+
+func (dc *dnsRecordController) deleteService(obj interface{}) {
+	// do nothing
+}
+
+func (dc *dnsRecordController) addPod(obj interface{}) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	if len(pod.Spec.NodeName) == 0 {
+		klog.V(2).Infof("the raven agent pod %v is not scheduled to the specified node", pod.Name)
+		return
+	}
+	if pod.DeletionTimestamp != nil {
+		dc.deletePod(pod)
+		return
+	}
+	klog.V(2).Infof("enqueue raven agent pod add event for %v", pod.Name)
+	dc.enqueue(PodAdd, pod)
+}
+
+func (dc *dnsRecordController) updatePod(oldObj, newObj interface{}) {
+	oldPod, ok := oldObj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	newPod, ok := newObj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	if len(newPod.Spec.NodeName) == 0 {
+		klog.V(2).Infof("the raven agent pod %v is not scheduled to the specified node", newPod.Name)
+		return
+	}
+
+	if oldPod.Spec.NodeName == newPod.Spec.NodeName {
+		return
+	}
+	klog.V(2).Infof("enqueue raven agent pod update event for %v", newPod.Name)
+	dc.enqueue(PodUpdate, newPod)
+}
+
+func (dc *dnsRecordController) deletePod(obj interface{}) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("can not get object from tombstone %#v", obj))
+			return
+		}
+		pod, ok = tombstone.Obj.(*corev1.Pod)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object is not a node %#v", obj))
+			return
+		}
+	}
+	if len(pod.Spec.NodeName) == 0 {
+		klog.V(2).Infof("the raven agent pod %v is not in pod", pod.Name)
+		return
+	}
+	klog.V(2).Infof("enqueue raven agent pod delete event for %v", pod.Name)
+	dc.enqueue(PodDelete, pod)
+}

--- a/pkg/dnscontroller/handler_test.go
+++ b/pkg/dnscontroller/handler_test.go
@@ -1,0 +1,1422 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnscontroller
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	client "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	tunnelIP = "172.168.0.1"
+)
+
+func TestDnsRecordController_AddNode(t *testing.T) {
+
+	testcases := []struct {
+		desc     string
+		useCache bool
+		client   client.Interface
+		nodes    []*corev1.Node
+		pods     []*corev1.Pod
+		services []*corev1.Service
+		expect   []string
+	}{
+		{
+			desc:     "add a cloud node",
+			useCache: false,
+			client: fake.NewSimpleClientset(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenDNSRecordConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						RavenDNSRecordNodeDataKey: "",
+					},
+				},
+			),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cloud-node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "false",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.1",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cloud-node-2",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "false",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.2",
+							},
+						},
+					},
+				},
+			},
+			pods: []*corev1.Pod{},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: tunnelIP,
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			expect: []string{
+				formatDNSRecord("192.168.0.1", "cloud-node-1"),
+				formatDNSRecord("192.168.0.2", "cloud-node-2"),
+			},
+		},
+		{
+			desc:     "add a edge node",
+			useCache: false,
+			client: fake.NewSimpleClientset(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenDNSRecordConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						RavenDNSRecordNodeDataKey: "",
+					},
+				},
+			),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "edge-node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.1.1",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "edge-node-2",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.1.2",
+							},
+						},
+					},
+				},
+			},
+			pods: []*corev1.Pod{},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: tunnelIP,
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			expect: []string{
+				formatDNSRecord("192.168.1.1", "edge-node-1"),
+				formatDNSRecord("192.168.1.2", "edge-node-2"),
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeDnsController(tt.client, tt.nodes, tt.pods, tt.services)
+			for _, node := range tt.nodes {
+				fakeDc.addNode(node)
+			}
+			go func() {
+				for {
+					time.Sleep(100 * time.Millisecond)
+					if fakeDc.queue.Len() == 0 {
+						fakeDc.queue.ShutDown()
+					}
+				}
+			}()
+			fakeDc.worker()
+			cm, err := fakeDc.client.CoreV1().ConfigMaps(RavenProxyResourceNamespace).Get(context.TODO(), ravenDNSRecordConfigMapName, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("failed to get configmap, %v", err)
+			}
+			get := strings.Split(cm.Data[RavenDNSRecordNodeDataKey], "\n")
+
+			sort.Strings(tt.expect)
+			sort.Strings(get)
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Errorf("expect to get records %v, but got %v", tt.expect, get)
+			}
+
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}
+
+func TestDnsRecordController_UpdateNode(t *testing.T) {
+	tunnelIP := "172.168.0.1"
+	testcases := []struct {
+		desc     string
+		useCache bool
+		client   client.Interface
+		nodes    []*corev1.Node
+		pods     []*corev1.Pod
+		services []*corev1.Service
+		expect   []string
+	}{
+		{
+			desc:     "update cloud node to edge node without raven agent",
+			useCache: false,
+			client: fake.NewSimpleClientset(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenDNSRecordConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						RavenDNSRecordNodeDataKey: "192.168.0.1\tnode-1",
+					},
+				},
+			),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "false",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.1",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.1.1",
+							},
+						},
+					},
+				},
+			},
+			pods: []*corev1.Pod{},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: tunnelIP,
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			expect: []string{
+				formatDNSRecord("192.168.1.1", "node-1"),
+			},
+		},
+		{
+			desc:     "update edge node to cloud node without raven agent",
+			useCache: false,
+			client: fake.NewSimpleClientset(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenDNSRecordConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						RavenDNSRecordNodeDataKey: "192.168.1.1\tnode-1",
+					},
+				},
+			),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.1.1",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "false",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.1",
+							},
+						},
+					},
+				},
+			},
+			pods: []*corev1.Pod{},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: tunnelIP,
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			expect: []string{
+				formatDNSRecord("192.168.0.1", "node-1"),
+			},
+		},
+		{
+			desc:     "update cloud node to edge node with raven agent",
+			useCache: false,
+			client: fake.NewSimpleClientset(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenDNSRecordConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						RavenDNSRecordNodeDataKey: "192.168.0.1\tnode-1",
+					},
+				},
+			),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "false",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.1",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.1.1",
+							},
+						},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							RavenAgentPodLabelKey: RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "node-1",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: tunnelIP,
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			expect: []string{
+				formatDNSRecord(tunnelIP, "node-1"),
+			},
+		},
+		{
+			desc:     "update edge node to cloud node raven agent",
+			useCache: false,
+			client: fake.NewSimpleClientset(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenDNSRecordConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						RavenDNSRecordNodeDataKey: "172.168.0.1\tnode-1",
+					},
+				},
+			),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.1.1",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "false",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.1",
+							},
+						},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							RavenAgentPodLabelKey: RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "node-1",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: tunnelIP,
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			expect: []string{
+				formatDNSRecord("192.168.0.1", "node-1"),
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeDnsController(tt.client, tt.nodes, tt.pods, tt.services)
+			fakeDc.updateNode(tt.nodes[0], tt.nodes[1])
+			go func() {
+				for {
+					time.Sleep(100 * time.Millisecond)
+					if fakeDc.queue.Len() == 0 {
+						fakeDc.queue.ShutDown()
+					}
+				}
+			}()
+			fakeDc.worker()
+			cm, err := fakeDc.client.CoreV1().ConfigMaps(RavenProxyResourceNamespace).Get(context.TODO(), ravenDNSRecordConfigMapName, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("failed to get configmap, %v", err)
+			}
+			get := strings.Split(cm.Data[RavenDNSRecordNodeDataKey], "\n")
+
+			sort.Strings(tt.expect)
+			sort.Strings(get)
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Errorf("expect to get records %v, but got %v", tt.expect, get)
+			}
+
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}
+
+func TestDnsRecordController_DeleteNode(t *testing.T) {
+	tunnelIP := "172.168.0.1"
+	testcases := []struct {
+		desc     string
+		useCache bool
+		client   client.Interface
+		nodes    []*corev1.Node
+		pods     []*corev1.Pod
+		services []*corev1.Service
+		expect   []string
+	}{
+		{
+			desc:     "delete a cloud node",
+			useCache: false,
+			client: fake.NewSimpleClientset(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenDNSRecordConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						RavenDNSRecordNodeDataKey: "192.168.0.1\tcloud-node-1\n192.168.0.2\tcloud-node-2",
+					},
+				},
+			),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cloud-node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "false",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.1",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cloud-node-2",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "false",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.2",
+							},
+						},
+					},
+				},
+			},
+			pods: []*corev1.Pod{},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: tunnelIP,
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			expect: []string{
+				formatDNSRecord("192.168.0.1", "cloud-node-1"),
+			},
+		},
+		{
+			desc:     "delete a edge node",
+			useCache: false,
+			client: fake.NewSimpleClientset(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenDNSRecordConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						RavenDNSRecordNodeDataKey: "192.168.1.1\tedge-node-1\n192.168.1.2\tedge-node-2",
+					},
+				},
+			),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "edge-node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.1.1",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "edge-node-2",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.1.2",
+							},
+						},
+					},
+				},
+			},
+			pods: []*corev1.Pod{},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: tunnelIP,
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			expect: []string{
+				formatDNSRecord("192.168.1.1", "edge-node-1"),
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeDnsController(tt.client, tt.nodes, tt.pods, tt.services)
+			fakeDc.deleteNode(tt.nodes[1])
+			go func() {
+				for {
+					time.Sleep(100 * time.Millisecond)
+					if fakeDc.queue.Len() == 0 {
+						fakeDc.queue.ShutDown()
+					}
+				}
+			}()
+			fakeDc.worker()
+			cm, err := fakeDc.client.CoreV1().ConfigMaps(RavenProxyResourceNamespace).Get(context.TODO(), ravenDNSRecordConfigMapName, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("failed to get configmap, %v", err)
+			}
+			get := strings.Split(cm.Data[RavenDNSRecordNodeDataKey], "\n")
+
+			sort.Strings(tt.expect)
+			sort.Strings(get)
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Errorf("expect to get records %v, but got %v", tt.expect, get)
+			}
+
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}
+
+func TestDnsRecordController_AddService(t *testing.T) {
+	testcases := []struct {
+		desc     string
+		client   client.Interface
+		nodes    []*corev1.Node
+		pods     []*corev1.Pod
+		services []*corev1.Service
+		expect   []string
+	}{
+		{
+			desc: fmt.Sprintf("add service %s/%s", RavenProxyResourceNamespace, RavenProxyInternalServiceName),
+			client: fake.NewSimpleClientset(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ravenDNSRecordConfigMapName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Data: map[string]string{
+					RavenDNSRecordNodeDataKey: "192.168.0.1\tcloud-node-1\n192.168.0.2\tedge-node-1\n192.168.0.3\tedge-node-2",
+				},
+			}),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cloud-node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "false",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.1",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "edge-node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.2",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "edge-node-2",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.3",
+							},
+						},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod-1",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							RavenAgentPodLabelKey: RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "cloud-node-1",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod-2",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							RavenAgentPodLabelKey: RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "edge-node-1",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod-3",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							RavenAgentPodLabelKey: RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "edge-node-2",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			expect: []string{
+				formatDNSRecord("192.168.0.1", "cloud-node-1"),
+				formatDNSRecord(tunnelIP, "edge-node-1"),
+				formatDNSRecord(tunnelIP, "edge-node-2"),
+			},
+		},
+	}
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeDnsController(tt.client, tt.nodes, tt.pods, tt.services)
+			fakeDc.addService(tt.services[0])
+			go func() {
+				for {
+					time.Sleep(100 * time.Millisecond)
+					if fakeDc.queue.Len() == 0 {
+						fakeDc.queue.ShutDown()
+					}
+				}
+			}()
+			fakeDc.worker()
+			cm, err := fakeDc.client.CoreV1().ConfigMaps(RavenProxyResourceNamespace).Get(context.TODO(), ravenDNSRecordConfigMapName, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("failed to get configmap, %v", err)
+			}
+			get := strings.Split(cm.Data[RavenDNSRecordNodeDataKey], "\n")
+
+			sort.Strings(tt.expect)
+			sort.Strings(get)
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Errorf("expect to get records %v, but got %v", tt.expect, get)
+			}
+
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}
+
+func TestDnsRecordController_UpdateService(t *testing.T) {
+	testcases := []struct {
+		desc     string
+		client   client.Interface
+		nodes    []*corev1.Node
+		pods     []*corev1.Pod
+		services []*corev1.Service
+		expect   []string
+	}{
+		{
+			desc: fmt.Sprintf("add service %s/%s", RavenProxyResourceNamespace, RavenProxyInternalServiceName),
+			client: fake.NewSimpleClientset(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ravenDNSRecordConfigMapName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Data: map[string]string{
+					RavenDNSRecordNodeDataKey: "192.168.0.1\tcloud-node-1\n172.168.0.1\tedge-node-1\n172.168.0.1\tedge-node-2",
+				},
+			}),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cloud-node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "false",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.1",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "edge-node-1",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.2",
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "edge-node-2",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.3",
+							},
+						},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod-1",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							RavenAgentPodLabelKey: RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "cloud-node-1",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod-2",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							RavenAgentPodLabelKey: RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "edge-node-1",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod-3",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							RavenAgentPodLabelKey: RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "edge-node-2",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.1.1",
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			expect: []string{
+				formatDNSRecord("192.168.0.1", "cloud-node-1"),
+				formatDNSRecord("172.168.1.1", "edge-node-1"),
+				formatDNSRecord("172.168.1.1", "edge-node-2"),
+			},
+		},
+	}
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeDnsController(tt.client, tt.nodes, tt.pods, tt.services)
+			fakeDc.updateService(tt.services[0], tt.services[1])
+			go func() {
+				for {
+					time.Sleep(100 * time.Millisecond)
+					if fakeDc.queue.Len() == 0 {
+						fakeDc.queue.ShutDown()
+					}
+				}
+			}()
+			fakeDc.worker()
+			cm, err := fakeDc.client.CoreV1().ConfigMaps(RavenProxyResourceNamespace).Get(context.TODO(), ravenDNSRecordConfigMapName, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("failed to get configmap, %v", err)
+			}
+			get := strings.Split(cm.Data[RavenDNSRecordNodeDataKey], "\n")
+
+			sort.Strings(tt.expect)
+			sort.Strings(get)
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Errorf("expect to get records %v, but got %v", tt.expect, get)
+			}
+
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}
+
+func TestDnsRecordController_AddPod(t *testing.T) {
+
+	testcases := []struct {
+		desc     string
+		useCache bool
+		client   client.Interface
+		nodes    []*corev1.Node
+		pods     []*corev1.Pod
+		services []*corev1.Service
+		expect   []string
+	}{
+		{
+			desc:     "add a raven agent in cloud node",
+			useCache: false,
+			client: fake.NewSimpleClientset(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenDNSRecordConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						RavenDNSRecordNodeDataKey: "192.168.0.1\tcloud-node",
+					},
+				},
+			),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cloud-node",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "false",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.1",
+							},
+						},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							RavenAgentPodLabelKey: RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "cloud-node",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: tunnelIP,
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			expect: []string{
+				formatDNSRecord("192.168.0.1", "cloud-node"),
+			},
+		},
+		{
+			desc:     "add a raven pod in edge node",
+			useCache: false,
+			client: fake.NewSimpleClientset(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenDNSRecordConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						RavenDNSRecordNodeDataKey: "192.168.1.1\tedge-node",
+					},
+				},
+			),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "edge-node",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.1.1",
+							},
+						},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							RavenAgentPodLabelKey: RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "edge-node",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: tunnelIP,
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			expect: []string{
+				formatDNSRecord(tunnelIP, "edge-node"),
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeDnsController(tt.client, tt.nodes, tt.pods, tt.services)
+			for _, pod := range tt.pods {
+				fakeDc.addPod(pod)
+			}
+			go func() {
+				for {
+					time.Sleep(100 * time.Millisecond)
+					if fakeDc.queue.Len() == 0 {
+						fakeDc.queue.ShutDown()
+					}
+				}
+			}()
+			fakeDc.worker()
+			cm, err := fakeDc.client.CoreV1().ConfigMaps(RavenProxyResourceNamespace).Get(context.TODO(), ravenDNSRecordConfigMapName, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("failed to get configmap, %v", err)
+			}
+			get := strings.Split(cm.Data[RavenDNSRecordNodeDataKey], "\n")
+
+			sort.Strings(tt.expect)
+			sort.Strings(get)
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Errorf("expect to get records %v, but got %v", tt.expect, get)
+			}
+
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}
+
+func TestDnsRecordController_DeletePod(t *testing.T) {
+
+	testcases := []struct {
+		desc     string
+		useCache bool
+		client   client.Interface
+		nodes    []*corev1.Node
+		pods     []*corev1.Pod
+		services []*corev1.Service
+		expect   []string
+	}{
+		{
+			desc:     "delete a raven agent in cloud node",
+			useCache: false,
+			client: fake.NewSimpleClientset(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenDNSRecordConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						RavenDNSRecordNodeDataKey: "192.168.0.1\tcloud-node",
+					},
+				},
+			),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cloud-node",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "false",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.0.1",
+							},
+						},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							RavenAgentPodLabelKey: RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "cloud-node",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: tunnelIP,
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			expect: []string{
+				formatDNSRecord("192.168.0.1", "cloud-node"),
+			},
+		},
+		{
+			desc:     "add a raven pod in edge node",
+			useCache: false,
+			client: fake.NewSimpleClientset(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenDNSRecordConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						RavenDNSRecordNodeDataKey: "172.168.0.1\tedge-node",
+					},
+				},
+			),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "edge-node",
+						Labels: map[string]string{
+							"openyurt.io/is-edge-worker": "true",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeInternalIP,
+								Address: "192.168.1.1",
+							},
+						},
+					},
+				},
+			},
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							RavenAgentPodLabelKey: RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "edge-node",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: tunnelIP,
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			expect: []string{
+				formatDNSRecord("192.168.1.1", "edge-node"),
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeDnsController(tt.client, tt.nodes, tt.pods, tt.services)
+			fakeDc.deletePod(tt.pods[0])
+			go func() {
+				for {
+					time.Sleep(100 * time.Millisecond)
+					if fakeDc.queue.Len() == 0 {
+						fakeDc.queue.ShutDown()
+					}
+				}
+			}()
+			fakeDc.worker()
+			cm, err := fakeDc.client.CoreV1().ConfigMaps(RavenProxyResourceNamespace).Get(context.TODO(), ravenDNSRecordConfigMapName, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("failed to get configmap, %v", err)
+			}
+			get := strings.Split(cm.Data[RavenDNSRecordNodeDataKey], "\n")
+
+			sort.Strings(tt.expect)
+			sort.Strings(get)
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Errorf("expect to get records %v, but got %v", tt.expect, get)
+			}
+
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}

--- a/pkg/dnscontroller/informer.go
+++ b/pkg/dnscontroller/informer.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnscontroller
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+// RegisterInformersForDNS registers shared informers that tunnel server use.
+func RegisterInformersForDNS(informerFactory informers.SharedInformerFactory) {
+	// register filtered service informers
+	informerFactory.InformerFor(&corev1.Service{}, newServiceInformer)
+
+	// register filtered pod informers
+	informerFactory.InformerFor(&corev1.Pod{}, newPodInformer)
+}
+
+// newServiceInformer creates a shared index informers that returns services related to yurttunnel
+func newServiceInformer(client clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+
+	tweakListOptions := func(options *metav1.ListOptions) {
+		options.LabelSelector = fmt.Sprintf("%v=%v", ravenProxyServiceLabelKey, ravenProxyServiceLabelValue)
+		options.FieldSelector = fmt.Sprintf("%s=%s", "metadata.name", RavenProxyInternalServiceName)
+	}
+	serviceIndexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	return coreinformers.NewFilteredServiceInformer(client, RavenProxyResourceNamespace, resyncPeriod, serviceIndexers, tweakListOptions)
+}
+
+// newPodInformer creates a shared index informers that returns only interested pods
+func newPodInformer(cs clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+
+	selector := fmt.Sprintf("%s=%s", RavenAgentPodLabelKey, RavenAgentPodLabelValue)
+	tweakListOptions := func(options *metav1.ListOptions) {
+		options.LabelSelector = selector
+	}
+
+	podIndexers := cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		NodeNameKeyIndex:     NodeNameIndexFunc,
+	}
+
+	return coreinformers.NewFilteredPodInformer(cs, RavenProxyResourceNamespace, resyncPeriod, podIndexers, tweakListOptions)
+}
+
+func NodeNameIndexFunc(obj interface{}) ([]string, error) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return []string{}, nil
+	}
+	if len(pod.Spec.NodeName) == 0 {
+		return []string{}, nil
+	}
+	return []string{pod.Spec.NodeName}, nil
+}

--- a/pkg/dnscontroller/util.go
+++ b/pkg/dnscontroller/util.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnscontroller
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openyurtio/raven-controller-manager/pkg/projectinfo"
+)
+
+// GetRavenDNSRecordConfigMapName get the configmap named yurt-tunnel-nodes
+func GetRavenDNSRecordConfigMapName() string {
+	return fmt.Sprintf(RavenDNSRecordConfigMapName,
+		strings.TrimRightFunc(projectinfo.GetProjectPrefix(), func(c rune) bool { return c == '-' }))
+}
+
+// GetRavenProxyServiceLabelKey get the label key of raven service : yurt-app
+func GetRavenProxyServiceLabelKey() string {
+	return fmt.Sprintf(RavenProxyServiceLabelKey,
+		strings.TrimRightFunc(projectinfo.GetProjectPrefix(), func(c rune) bool { return c == '-' }))
+}
+
+// GetRavenProxyServiceLabelValue get the label value of raven service : yurt-tunnel-server
+func GetRavenProxyServiceLabelValue() string {
+	return fmt.Sprintf(RavenProxyServiceLabelValue,
+		strings.TrimRightFunc(projectinfo.GetProjectPrefix(), func(c rune) bool { return c == '-' }))
+}
+
+func isEdgeNode(node *corev1.Node) bool {
+	f, ok := node.Labels[projectinfo.GetEdgeWorkerLabelKey()]
+	if ok && f == "true" {
+		return true
+	}
+	return false
+}
+
+func formatDNSRecord(ip, host string) string {
+	return fmt.Sprintf("%s\t%s", ip, host)
+}
+
+func getNodeHostIP(node *corev1.Node) (string, error) {
+	// get InternalIPs first and then ExternalIPs
+	allIPs := make([]net.IP, 0, len(node.Status.Addresses))
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP {
+			ip := net.ParseIP(addr.Address)
+			if ip != nil {
+				allIPs = append(allIPs, ip)
+				break
+			}
+		}
+	}
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeExternalIP {
+			ip := net.ParseIP(addr.Address)
+			if ip != nil {
+				allIPs = append(allIPs, ip)
+				break
+			}
+		}
+	}
+	if len(allIPs) == 0 {
+		return "", fmt.Errorf("host IP unknown; known addresses: %v", node.Status.Addresses)
+	}
+
+	return allIPs[0].String(), nil
+}
+
+func strToMap(src *string) (dst map[string]string) {
+	dst = make(map[string]string, 0)
+	if len(*src) == 0 {
+		return
+	}
+	records := strings.Split(*src, "\n")
+	for _, record := range records {
+		data := strings.Split(record, "\t")
+		if len(data) != 2 {
+			continue
+		}
+		dst[data[1]] = data[0]
+	}
+	return
+}
+
+func mapToStr(src *map[string]string) (dst string) {
+	if len(*src) == 0 {
+		return ""
+	}
+	records := make([]string, 0, len(*src))
+	for nodeName, address := range *src {
+		records = append(records, formatDNSRecord(address, nodeName))
+	}
+	sort.Strings(records)
+	return strings.Join(records, "\n")
+}

--- a/pkg/dnscontroller/util_test.go
+++ b/pkg/dnscontroller/util_test.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnscontroller
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_IsEdgeNode(t *testing.T) {
+	testcases := []struct {
+		desc   string
+		node   *corev1.Node
+		expect bool
+	}{
+		{
+			desc: "the node is cloud node",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-1",
+					Labels: map[string]string{
+						"openyurt.io/is-edge-worker": "false",
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			desc: "the node is edge node",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-2",
+					Labels: map[string]string{
+						"openyurt.io/is-edge-worker": "true",
+					},
+				},
+			},
+			expect: true,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			get := isEdgeNode(tt.node)
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect, get)
+			}
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}
+
+func Test_FormatDNSRecord(t *testing.T) {
+	testcases := []struct {
+		desc   string
+		ip     string
+		host   string
+		expect string
+	}{
+		{
+			desc:   "format dns record",
+			ip:     "168.172.0.1",
+			host:   "node-1",
+			expect: "168.172.0.1\tnode-1",
+		},
+		{
+			desc:   "format dns record",
+			ip:     "168.172.0.2",
+			host:   "node-2",
+			expect: "168.172.0.2\tnode-2",
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			get := formatDNSRecord(tt.ip, tt.host)
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect, get)
+			}
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}
+
+func Test_GetNodeHostIP(t *testing.T) {
+	testcases := []struct {
+		desc   string
+		node   *corev1.Node
+		expect string
+	}{
+		{
+			desc: "the node has no host ip",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-1",
+					Labels: map[string]string{
+						"openyurt.io/is-edge-worker": "false",
+					},
+				},
+			},
+			expect: "",
+		},
+		{
+			desc: "the type of address is internal ip",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-2",
+					Labels: map[string]string{
+						"openyurt.io/is-edge-worker": "false",
+					},
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{
+							Type:    corev1.NodeInternalIP,
+							Address: "192.168.0.1",
+						},
+					},
+				},
+			},
+			expect: "192.168.0.1",
+		},
+		{
+			desc: "the type of address is external ip",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-3",
+					Labels: map[string]string{
+						"openyurt.io/is-edge-worker": "true",
+					},
+				},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{
+							Type:    corev1.NodeExternalIP,
+							Address: "172.168.0.1",
+						},
+					},
+				},
+			},
+			expect: "172.168.0.1",
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			get, _ := getNodeHostIP(tt.node)
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect, get)
+			}
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}
+
+func Test_StrToMap(t *testing.T) {
+	testcases := []struct {
+		desc   string
+		dns    string
+		expect map[string]string
+	}{
+		{
+			desc: "convert dns record from string to map",
+			dns:  "168.172.0.1\tnode-1\n168.172.0.2\tnode-2\n168.172.0.3\tnode-3",
+			expect: map[string]string{
+				"node-1": "168.172.0.1",
+				"node-2": "168.172.0.2",
+				"node-3": "168.172.0.3",
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			get := strToMap(&tt.dns)
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect, get)
+			}
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}
+
+func Test_MapToStr(t *testing.T) {
+	testcases := []struct {
+		desc   string
+		dns    map[string]string
+		expect string
+	}{
+		{
+			desc: "convert dns record from map to string",
+			dns: map[string]string{
+				"node-1": "168.172.0.1",
+				"node-2": "168.172.0.2",
+				"node-3": "168.172.0.3",
+			},
+			expect: "168.172.0.1\tnode-1\n168.172.0.2\tnode-2\n168.172.0.3\tnode-3",
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			get := mapToStr(&tt.dns)
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect, get)
+			}
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}

--- a/pkg/dnscontroller/worker.go
+++ b/pkg/dnscontroller/worker.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnscontroller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+func (dc *dnsRecordController) onAddNode(node *corev1.Node) error {
+
+	dnsRecords, err := dc.getCurrentRavenDNSRecord()
+	if err != nil {
+		return err
+	}
+
+	ip, err := getNodeHostIP(node)
+	if err != nil {
+		klog.Fatalf("failed to parse node address for %v, %v", node.Name, err)
+		return err
+	}
+
+	dnsRecordsMap := strToMap(&dnsRecords)
+	dnsRecordsMap[node.Name] = ip
+	dnsRecordsStr := mapToStr(&dnsRecordsMap)
+
+	err = dc.updateCurrentRavenDNSRecord(dnsRecordsStr)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (dc *dnsRecordController) onUpdateNode(node *corev1.Node) error {
+	dnsRecords, err := dc.getCurrentRavenDNSRecord()
+	if err != nil {
+		return err
+	}
+
+	newIP, err := dc.getUpdatedNodeIP(node)
+	if err != nil {
+		klog.Fatalf("failed to get node address for %v, %v", node.Name, err)
+		return err
+	}
+
+	dnsRecordsMap := strToMap(&dnsRecords)
+	if oldIP, ok := dnsRecordsMap[node.Name]; ok && oldIP != newIP {
+		dnsRecordsMap[node.Name] = newIP
+		dnsRecordsStr := mapToStr(&dnsRecordsMap)
+
+		err = dc.updateCurrentRavenDNSRecord(dnsRecordsStr)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (dc *dnsRecordController) getUpdatedNodeIP(node *corev1.Node) (string, error) {
+
+	ip, err := getNodeHostIP(node)
+	if err != nil {
+		klog.Fatalf("failed to parse node address for %v, %v", node.Name, err)
+		return "", err
+	}
+
+	//check whether the raven-agent is on the node
+	if isEdgeNode(node) && dc.hasRavenAgentPod(node.Name) {
+		ip, err = dc.getRavenInternalServiceIP(true)
+	}
+
+	return ip, err
+}
+
+func (dc *dnsRecordController) onDeleteNode(node *corev1.Node) error {
+	dnsRecords, err := dc.getCurrentRavenDNSRecord()
+	if err != nil {
+		return err
+	}
+
+	dnsRecordsMap := strToMap(&dnsRecords)
+	if _, ok := dnsRecordsMap[node.Name]; ok {
+		delete(dnsRecordsMap, node.Name)
+		dnsRecordsStr := mapToStr(&dnsRecordsMap)
+		err = dc.updateCurrentRavenDNSRecord(dnsRecordsStr)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (dc *dnsRecordController) onAddService() error {
+	dc.syncDNSRecordAsWhole()
+	return nil
+}
+
+func (dc *dnsRecordController) onUpdateService() error {
+	dc.syncDNSRecordAsWhole()
+	return nil
+}
+
+func (dc *dnsRecordController) onAddPod(pod *corev1.Pod) error {
+	return dc.updateRecordAccordingPod(pod, false)
+}
+
+func (dc *dnsRecordController) onUpdatePod(pod *corev1.Pod) error {
+	return dc.updateRecordAccordingPod(pod, false)
+}
+
+func (dc *dnsRecordController) onDeletePod(pod *corev1.Pod) error {
+	return dc.updateRecordAccordingPod(pod, true)
+}
+
+func (dc *dnsRecordController) getCurrentRavenDNSRecord() (string, error) {
+	cm, err := dc.client.CoreV1().ConfigMaps(RavenProxyResourceNamespace).
+		Get(context.TODO(), ravenDNSRecordConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	data, ok := cm.Data[RavenDNSRecordNodeDataKey]
+	if !ok || len(data) == 0 {
+		return "", nil
+	}
+
+	return data, nil
+}
+
+func (dc *dnsRecordController) updateCurrentRavenDNSRecord(newRecords string) error {
+	cm, err := dc.client.CoreV1().ConfigMaps(RavenProxyResourceNamespace).
+		Get(context.TODO(), ravenDNSRecordConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data[RavenDNSRecordNodeDataKey] = newRecords
+	if _, err := dc.client.CoreV1().ConfigMaps(RavenProxyResourceNamespace).
+		Update(context.TODO(), cm, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("failed to update configmap %v/%v, %w",
+			RavenProxyResourceNamespace, ravenDNSRecordConfigMapName, err)
+	}
+	return nil
+}
+
+func (dc *dnsRecordController) hasRavenAgentPod(nodeName string) bool {
+
+	pods, err := dc.getPodsAssignedToNode(nodeName)
+	if err != nil {
+		klog.Errorf("failed to get raven agent pod that running in %s, err: %w", nodeName, err)
+		return false
+	}
+	if len(pods) < 1 {
+		return false
+	}
+	for _, pod := range pods {
+		if pod.Status.Phase == corev1.PodRunning {
+			return true
+		}
+	}
+	klog.Infof("there is no running raven agent pod in node %s", nodeName)
+	return false
+}
+
+func (dc *dnsRecordController) updateRecordAccordingPod(pod *corev1.Pod, isDelete bool) error {
+	node, err := dc.dnsSharedInformer.nodeLister.Get(pod.Spec.NodeName)
+	if err != nil {
+		return err
+	}
+
+	ip, err := getNodeHostIP(node)
+	if err != nil {
+		klog.Fatalf("failed to parse node address for %v, %v", node.Name, err)
+		return err
+	}
+
+	if isEdgeNode(node) && !isDelete {
+		ip, err = dc.getRavenInternalServiceIP(true)
+		if err != nil {
+			return err
+		}
+	}
+
+	dnsRecords, err := dc.getCurrentRavenDNSRecord()
+	if err != nil {
+		return err
+	}
+	dnsRecordsMap := strToMap(&dnsRecords)
+	dnsRecordsMap[node.Name] = ip
+	dnsRecordsStr := mapToStr(&dnsRecordsMap)
+	return dc.updateCurrentRavenDNSRecord(dnsRecordsStr)
+}

--- a/pkg/projectinfo/projectinfo.go
+++ b/pkg/projectinfo/projectinfo.go
@@ -22,10 +22,23 @@ import (
 )
 
 var (
-	gitVersion = "v0.0.0"
-	gitCommit  = "unknown"
-	buildDate  = "1970-01-01T00:00:00Z"
+	gitVersion    = "v0.0.0"
+	gitCommit     = "unknown"
+	buildDate     = "1970-01-01T00:00:00Z"
+	projectPrefix = "yurt"
+	labelPrefix   = "openyurt.io"
 )
+
+// The project prefix is yurt
+func GetProjectPrefix() string {
+	return projectPrefix
+}
+
+// GetEdgeWorkerLabelKey returns the edge-worker node label ("openyurt.io/is-edge-worker"),
+// which is used to identify if a node is edge node ("true") or cloud node ("false")
+func GetEdgeWorkerLabelKey() string {
+	return labelPrefix + "/is-edge-worker"
+}
 
 // normalizeGitCommit reserve 7 characters for gitCommit
 func normalizeGitCommit(commit string) string {

--- a/pkg/servicecontroller/constants.go
+++ b/pkg/servicecontroller/constants.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicecontroller
+
+import "github.com/openyurtio/raven-controller-manager/pkg/dnscontroller"
+
+const (
+	RavenProxyInternalServiceName = "x-raven-server-internal-svc"
+	RavenProxyResourceNamespace   = "kube-system"
+
+	RavenProxyDNATConfigMapName = "%s-tunnel-server-cfg"
+	RavenServerLabelKey         = "%s-app"
+	RavenServerLabelValue       = "%s-tunnel-server"
+
+	RavenServerHTTPProxyPorts  = "http-proxy-ports"
+	RavenServerHTTPSProxyPorts = "https-proxy-ports"
+	RavenExtendedPort          = "extend"
+
+	SecurePort       = "10263"
+	InsecurePort     = "10264"
+	KubeletHTTPSPort = "10250"
+	KubeletHTTPPort  = "10255"
+	MinPort          = 1
+	MaxPort          = 65535
+	MaxRetries       = 15
+	MinSyncPeriod    = 30
+)
+
+var (
+	ravenProxyPortConfigMapName = GetRavenProxyPortConfigMapName()
+	ravenProxyServiceLabelKey   = dnscontroller.GetRavenProxyServiceLabelKey()
+	ravenProxyServiceLabelValue = dnscontroller.GetRavenProxyServiceLabelValue()
+	ravenServerLabelKey         = GetRavenServerLabelKey()
+	ravenServerLabelValue       = GetRavenServerLabelValue()
+)

--- a/pkg/servicecontroller/event.go
+++ b/pkg/servicecontroller/event.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicecontroller
+
+type EventType string
+
+const (
+	ServiceAdd      EventType = "SERVICE_ADD"
+	ConfigMapAdd    EventType = "CONFIGMAP_ADD"
+	ConfigMapUpdate EventType = "CONFIGMAP_UPDATE"
+	ConfigMapDelete EventType = "CONFIGMAP_DELETE"
+	GatewayAdd      EventType = "GATEWAY_ADD"
+	GatewayUpdate   EventType = "GATEWAY_Update"
+	GatewayDelete   EventType = "GATEWAY_Delete"
+)
+
+type Event struct {
+	Type EventType
+	Obj  interface{}
+}

--- a/pkg/servicecontroller/handler.go
+++ b/pkg/servicecontroller/handler.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicecontroller
+
+import (
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	ravenv1alpha1 "github.com/openyurtio/raven-controller-manager/pkg/ravencontroller/apis/raven/v1alpha1"
+)
+
+func (sc *serviceController) addService(obj interface{}) {
+	svc, ok := obj.(*corev1.Service)
+	if !ok {
+		return
+	}
+	if svc.DeletionTimestamp != nil {
+		return
+	}
+	if svc.Name != RavenProxyInternalServiceName {
+		return
+	}
+	klog.V(2).Infof("enqueue service add event for %v/%v", svc.Namespace, svc.Name)
+	sc.enqueue(ServiceAdd, svc)
+}
+
+func (sc *serviceController) addConfigMap(obj interface{}) {
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		return
+	}
+	if cm.DeletionTimestamp != nil {
+		sc.deleteConfigMap(cm)
+		return
+	}
+	klog.V(2).Infof("enqueue configmap add event for %v/%v", cm.Namespace, cm.Name)
+	sc.enqueue(ConfigMapAdd, cm)
+}
+
+func (sc *serviceController) updateConfigMap(oldObj, newObj interface{}) {
+	oldConfigMap, ok := oldObj.(*corev1.ConfigMap)
+	if !ok {
+		return
+	}
+	newConfigMap, ok := newObj.(*corev1.ConfigMap)
+	if !ok {
+		return
+	}
+	if reflect.DeepEqual(oldConfigMap.Data, newConfigMap.Data) {
+		return
+	}
+
+	klog.V(2).Infof("enqueue configmap update event for %v/%v, will sync raven server svc", newConfigMap.Namespace, newConfigMap.Name)
+	sc.enqueue(ConfigMapUpdate, newConfigMap)
+}
+
+func (sc *serviceController) deleteConfigMap(obj interface{}) {
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("can not get object from tombstone %#v", obj))
+			return
+		}
+		cm, ok = tombstone.Obj.(*corev1.ConfigMap)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object is not a comfigmap %#v", obj))
+			return
+		}
+	}
+	klog.V(2).Infof("enqueue configmap delete event for %v/%v", cm.Namespace, cm.Name)
+	sc.enqueue(ConfigMapDelete, cm)
+}
+
+func (sc *serviceController) addGateWay(obj interface{}) {
+	gw, ok := obj.(*ravenv1alpha1.Gateway)
+	if !ok {
+		return
+	}
+	if gw.Status.ActiveEndpoint == nil || len(gw.Status.ActiveEndpoint.NodeName) < 1 {
+		klog.V(2).Infof("the gateway node has not been selected in gateway %s", gw.Name)
+		return
+	}
+	klog.V(2).Infof("enqueue gateway add event for %v", gw.Name)
+	sc.enqueue(GatewayAdd, gw)
+}
+
+func (sc *serviceController) updateGateWay(oldObj, newObj interface{}) {
+	oldGw, ok := oldObj.(*ravenv1alpha1.Gateway)
+	if !ok {
+		return
+	}
+
+	newGw, ok := newObj.(*ravenv1alpha1.Gateway)
+	if !ok {
+		return
+	}
+
+	if oldGw.Status.ActiveEndpoint == nil || len(oldGw.Status.ActiveEndpoint.NodeName) < 1 {
+		return
+	}
+	klog.V(2).Infof("enqueue gateway delete event for %v", oldGw.Name)
+	sc.enqueue(GatewayDelete, oldGw)
+
+	if newGw.Status.ActiveEndpoint == nil || len(newGw.Status.ActiveEndpoint.NodeName) < 1 {
+		return
+	}
+	klog.V(2).Infof("enqueue gateway update event for %v", newGw.Name)
+	sc.enqueue(GatewayUpdate, newGw)
+
+}
+
+func (sc *serviceController) deleteGateWay(obj interface{}) {
+	gw, ok := obj.(*ravenv1alpha1.Gateway)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("can not get object from tombstone %#v", obj))
+			return
+		}
+		gw, ok = tombstone.Obj.(*ravenv1alpha1.Gateway)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object is not a gateway %#v", obj))
+			return
+		}
+	}
+	klog.V(2).Infof("enqueue gateway delete event for %v", gw.Name)
+	sc.enqueue(GatewayDelete, gw)
+}

--- a/pkg/servicecontroller/handler_test.go
+++ b/pkg/servicecontroller/handler_test.go
@@ -1,0 +1,770 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicecontroller
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	client "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openyurtio/raven-controller-manager/pkg/dnscontroller"
+	ravenv1alpha1 "github.com/openyurtio/raven-controller-manager/pkg/ravencontroller/apis/raven/v1alpha1"
+	ravenClientset "github.com/openyurtio/raven-controller-manager/pkg/ravencontroller/client/clientset/versioned"
+	fakeRavenClientset "github.com/openyurtio/raven-controller-manager/pkg/ravencontroller/client/clientset/versioned/fake"
+)
+
+func TestServiceController_AddService(t *testing.T) {
+	testcases := []struct {
+		desc        string
+		kubeClient  client.Interface
+		ravenClient ravenClientset.Interface
+		gateway     []*ravenv1alpha1.Gateway
+		services    []*corev1.Service
+		configmap   []*corev1.ConfigMap
+		addService  *corev1.Service
+		expect      *corev1.Service
+	}{
+		{
+			desc: fmt.Sprintf("add services %s/%s", RavenProxyResourceNamespace, RavenProxyInternalServiceName),
+			kubeClient: fake.NewSimpleClientset(
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenProxyPortConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						"localhost-proxy-ports": "10266, 10267",
+						"http-proxy-ports":      "9445",
+						"https-proxy-ports":     "9100",
+					},
+				},
+			),
+			ravenClient: fakeRavenClientset.NewSimpleClientset(),
+			services:    []*corev1.Service{},
+			configmap: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenProxyPortConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						"localhost-proxy-ports": "10266, 10267",
+						"http-proxy-ports":      "9445",
+						"https-proxy-ports":     "9100",
+					},
+				},
+			},
+			addService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      RavenProxyInternalServiceName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "172.168.0.1",
+					Ports:     []corev1.ServicePort{},
+				},
+			},
+			expect: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      RavenProxyInternalServiceName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "172.168.0.1",
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "extend-9100",
+							Port:       9100,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10263),
+						},
+						{
+							Name:       "extend-9445",
+							Port:       9445,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10264),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeServiceController(tt.kubeClient, tt.ravenClient, tt.services, tt.configmap, tt.gateway)
+			fakeDc.addService(tt.addService)
+			go func() {
+				for {
+					time.Sleep(100 * time.Millisecond)
+					if fakeDc.queue.Len() == 0 {
+						fakeDc.queue.ShutDown()
+					}
+				}
+			}()
+			fakeDc.worker()
+			get, _ := getProxyPortService(fakeDc.kubeClient)
+
+			sort.Slice(get.Spec.Ports, func(i, j int) bool {
+				return get.Spec.Ports[i].Port >= get.Spec.Ports[j].Port
+			})
+
+			sort.Slice(tt.expect.Spec.Ports, func(i, j int) bool {
+				return tt.expect.Spec.Ports[i].Port >= tt.expect.Spec.Ports[j].Port
+			})
+
+			if !reflect.DeepEqual(get.Spec.Ports, tt.expect.Spec.Ports) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect.Spec.Ports, get.Spec.Ports)
+			}
+
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+
+		})
+	}
+}
+
+func TestServiceController_AddConfigMap(t *testing.T) {
+	testcases := []struct {
+		desc         string
+		kubeClient   client.Interface
+		ravenClient  ravenClientset.Interface
+		gateway      []*ravenv1alpha1.Gateway
+		services     []*corev1.Service
+		configmap    []*corev1.ConfigMap
+		addConfigMap *corev1.ConfigMap
+		expect       *corev1.Service
+	}{
+		{
+			desc: fmt.Sprintf("add configmap %s/%v", RavenProxyResourceNamespace, ravenProxyPortConfigMapName),
+			kubeClient: fake.NewSimpleClientset(
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			),
+			ravenClient: fakeRavenClientset.NewSimpleClientset(),
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			configmap: []*corev1.ConfigMap{},
+			gateway:   []*ravenv1alpha1.Gateway{},
+			addConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ravenProxyPortConfigMapName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Data: map[string]string{
+					"localhost-proxy-ports": "10266, 10267",
+					"http-proxy-ports":      "9445",
+					"https-proxy-ports":     "9100",
+				},
+			},
+			expect: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      RavenProxyInternalServiceName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "172.168.0.1",
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "extend-9100",
+							Port:       9100,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10263),
+						},
+						{
+							Name:       "extend-9445",
+							Port:       9445,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10264),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeServiceController(tt.kubeClient, tt.ravenClient, tt.services, tt.configmap, tt.gateway)
+			fakeDc.addConfigMap(tt.addConfigMap)
+			go func() {
+				for {
+					time.Sleep(100 * time.Millisecond)
+					if fakeDc.queue.Len() == 0 {
+						fakeDc.queue.ShutDown()
+					}
+				}
+			}()
+			fakeDc.worker()
+			get, _ := getProxyPortService(fakeDc.kubeClient)
+
+			sort.Slice(get.Spec.Ports, func(i, j int) bool {
+				return get.Spec.Ports[i].Port >= get.Spec.Ports[j].Port
+			})
+
+			sort.Slice(tt.expect.Spec.Ports, func(i, j int) bool {
+				return tt.expect.Spec.Ports[i].Port >= tt.expect.Spec.Ports[j].Port
+			})
+
+			if !reflect.DeepEqual(get.Spec.Ports, tt.expect.Spec.Ports) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect.Spec.Ports, get.Spec.Ports)
+			}
+
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+
+		})
+	}
+}
+
+func TestServiceController_UpdateConfigMap(t *testing.T) {
+	testcases := []struct {
+		desc         string
+		kubeClient   client.Interface
+		ravenClient  ravenClientset.Interface
+		gateway      []*ravenv1alpha1.Gateway
+		services     []*corev1.Service
+		configmap    []*corev1.ConfigMap
+		oldConfigMap *corev1.ConfigMap
+		newConfigMap *corev1.ConfigMap
+		expect       *corev1.Service
+	}{
+		{
+			desc: fmt.Sprintf("add configmap %s/%v", RavenProxyResourceNamespace, ravenProxyPortConfigMapName),
+			kubeClient: fake.NewSimpleClientset(
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenProxyPortConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						"localhost-proxy-ports": "10266, 10267",
+						"http-proxy-ports":      "9445",
+						"https-proxy-ports":     "9100",
+					},
+				},
+			),
+			ravenClient: fakeRavenClientset.NewSimpleClientset(),
+			gateway:     []*ravenv1alpha1.Gateway{},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			configmap: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenProxyPortConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						"localhost-proxy-ports": "10266, 10267",
+						"http-proxy-ports":      "9445",
+						"https-proxy-ports":     "9100",
+					},
+				},
+			},
+			oldConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ravenProxyPortConfigMapName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Data: map[string]string{
+					"localhost-proxy-ports": "10266, 10267",
+					"http-proxy-ports":      "9445",
+					"https-proxy-ports":     "9100",
+				},
+			},
+			newConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ravenProxyPortConfigMapName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Data: map[string]string{
+					"localhost-proxy-ports": "10266, 10267",
+					"http-proxy-ports":      "9445",
+					"https-proxy-ports":     "9100, 80",
+				},
+			},
+			expect: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      RavenProxyInternalServiceName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "172.168.0.1",
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "extend-9100",
+							Port:       9100,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10263),
+						},
+						{
+							Name:       "extend-9445",
+							Port:       9445,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10264),
+						},
+						{
+							Name:       "extend-80",
+							Port:       80,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10263),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeServiceController(tt.kubeClient, tt.ravenClient, tt.services, tt.configmap, tt.gateway)
+			fakeDc.updateConfigMap(tt.oldConfigMap, tt.newConfigMap)
+			go func() {
+				for {
+					time.Sleep(100 * time.Millisecond)
+					if fakeDc.queue.Len() == 0 {
+						fakeDc.queue.ShutDown()
+					}
+				}
+			}()
+			fakeDc.worker()
+			get, _ := getProxyPortService(fakeDc.kubeClient)
+
+			sort.Slice(get.Spec.Ports, func(i, j int) bool {
+				return get.Spec.Ports[i].Port >= get.Spec.Ports[j].Port
+			})
+
+			sort.Slice(tt.expect.Spec.Ports, func(i, j int) bool {
+				return tt.expect.Spec.Ports[i].Port >= tt.expect.Spec.Ports[j].Port
+			})
+
+			if !reflect.DeepEqual(get.Spec.Ports, tt.expect.Spec.Ports) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect.Spec.Ports, get.Spec.Ports)
+			}
+
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+
+		})
+	}
+}
+
+func TestServiceController_DeleteConfigMap(t *testing.T) {
+	testcases := []struct {
+		desc            string
+		kubeClient      client.Interface
+		ravenClient     ravenClientset.Interface
+		gateway         []*ravenv1alpha1.Gateway
+		services        []*corev1.Service
+		configmap       []*corev1.ConfigMap
+		deleteConfigMap *corev1.ConfigMap
+		expect          *corev1.Service
+	}{
+		{
+			desc: fmt.Sprintf("delete configmap %s/%v", RavenProxyResourceNamespace, ravenProxyPortConfigMapName),
+			kubeClient: fake.NewSimpleClientset(
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "extend-9100",
+								Port:       9100,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10263),
+							},
+							{
+								Name:       "extend-9445",
+								Port:       9445,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10264),
+							},
+							{
+								Name:       "extend-80",
+								Port:       80,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10263),
+							},
+						},
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenProxyPortConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						"localhost-proxy-ports": "10266, 10267",
+						"http-proxy-ports":      "9445",
+						"https-proxy-ports":     "9100",
+					},
+				},
+			),
+			ravenClient: fakeRavenClientset.NewSimpleClientset(),
+			gateway:     []*ravenv1alpha1.Gateway{},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "extend-9100",
+								Port:       9100,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10263),
+							},
+							{
+								Name:       "extend-9445",
+								Port:       9445,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10264),
+							},
+							{
+								Name:       "extend-80",
+								Port:       80,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10263),
+							},
+						},
+					},
+				},
+			},
+			configmap: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenProxyPortConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						"localhost-proxy-ports": "10266, 10267",
+						"http-proxy-ports":      "9445",
+						"https-proxy-ports":     "9100",
+					},
+				},
+			},
+			deleteConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ravenProxyPortConfigMapName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Data: map[string]string{
+					"localhost-proxy-ports": "10266, 10267",
+					"http-proxy-ports":      "9445",
+					"https-proxy-ports":     "9100",
+				},
+			},
+			expect: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      RavenProxyInternalServiceName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "172.168.0.1",
+					Ports:     []corev1.ServicePort{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeServiceController(tt.kubeClient, tt.ravenClient, tt.services, tt.configmap, tt.gateway)
+			fakeDc.deleteConfigMap(tt.deleteConfigMap)
+			go func() {
+				for {
+					time.Sleep(100 * time.Millisecond)
+					if fakeDc.queue.Len() == 0 {
+						fakeDc.queue.ShutDown()
+					}
+				}
+			}()
+			fakeDc.worker()
+			get, _ := getProxyPortService(fakeDc.kubeClient)
+
+			sort.Slice(get.Spec.Ports, func(i, j int) bool {
+				return get.Spec.Ports[i].Port > -get.Spec.Ports[j].Port
+			})
+
+			sort.Slice(tt.expect.Spec.Ports, func(i, j int) bool {
+				return tt.expect.Spec.Ports[i].Port < tt.expect.Spec.Ports[j].Port
+			})
+
+			if !reflect.DeepEqual(get.Spec.Ports, tt.expect.Spec.Ports) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect.Spec.Ports, get.Spec.Ports)
+			}
+
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+
+		})
+	}
+}
+
+func TestServiceController_AddGateWay(t *testing.T) {
+	testcases := []struct {
+		desc        string
+		kubeClient  client.Interface
+		ravenClient ravenClientset.Interface
+		gateway     []*ravenv1alpha1.Gateway
+		services    []*corev1.Service
+		configmap   []*corev1.ConfigMap
+		addGateway  *ravenv1alpha1.Gateway
+		expect      map[string]string
+	}{
+		{
+			desc: "add gateway",
+			kubeClient: fake.NewSimpleClientset(
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod-1",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							dnscontroller.RavenAgentPodLabelKey: dnscontroller.RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "gateway-node",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+			),
+			ravenClient: fakeRavenClientset.NewSimpleClientset(),
+			services:    []*corev1.Service{},
+			configmap:   []*corev1.ConfigMap{},
+			gateway: []*ravenv1alpha1.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cloud-nodepool",
+						Labels: map[string]string{
+							ravenServerLabelKey: ravenServerLabelValue,
+						},
+					},
+					Spec: ravenv1alpha1.GatewaySpec{},
+					Status: ravenv1alpha1.GatewayStatus{
+						ActiveEndpoint: &ravenv1alpha1.Endpoint{
+							NodeName: "gateway-node",
+						},
+					},
+				},
+			},
+			addGateway: &ravenv1alpha1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cloud-nodepool",
+					Labels: map[string]string{
+						ravenServerLabelKey: ravenServerLabelValue,
+					},
+				},
+				Spec: ravenv1alpha1.GatewaySpec{},
+				Status: ravenv1alpha1.GatewayStatus{
+					ActiveEndpoint: &ravenv1alpha1.Endpoint{
+						NodeName: "gateway-node",
+					},
+				},
+			},
+			expect: map[string]string{
+				dnscontroller.RavenAgentPodLabelKey: dnscontroller.RavenAgentPodLabelValue,
+				ravenServerLabelKey:                 ravenServerLabelValue,
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeServiceController(tt.kubeClient, tt.ravenClient, tt.services, tt.configmap, tt.gateway)
+			fakeDc.addGateWay(tt.addGateway)
+			go func() {
+				for {
+					time.Sleep(100 * time.Millisecond)
+					if fakeDc.queue.Len() == 0 {
+						fakeDc.queue.ShutDown()
+					}
+				}
+			}()
+			fakeDc.worker()
+			podList, _ := fakeDc.kubeClient.CoreV1().Pods(RavenProxyResourceNamespace).List(context.TODO(), metav1.ListOptions{})
+			get := podList.Items[0]
+			if !reflect.DeepEqual(get.Labels, tt.expect) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect, get.Labels)
+			}
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+
+		})
+	}
+}
+
+func TestServiceController_DeleteGateWay(t *testing.T) {
+	testcases := []struct {
+		desc          string
+		kubeClient    client.Interface
+		ravenClient   ravenClientset.Interface
+		gateway       []*ravenv1alpha1.Gateway
+		services      []*corev1.Service
+		configmap     []*corev1.ConfigMap
+		deleteGateway *ravenv1alpha1.Gateway
+		expect        map[string]string
+	}{
+		{
+			desc: "delete gateway",
+			kubeClient: fake.NewSimpleClientset(
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod-1",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							dnscontroller.RavenAgentPodLabelKey: dnscontroller.RavenAgentPodLabelValue,
+							ravenServerLabelKey:                 ravenServerLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "gateway-node",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+			),
+			ravenClient: fakeRavenClientset.NewSimpleClientset(),
+			services:    []*corev1.Service{},
+			configmap:   []*corev1.ConfigMap{},
+			gateway: []*ravenv1alpha1.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cloud-nodepool",
+						Labels: map[string]string{
+							ravenServerLabelKey: ravenServerLabelValue,
+						},
+					},
+					Spec: ravenv1alpha1.GatewaySpec{},
+					Status: ravenv1alpha1.GatewayStatus{
+						ActiveEndpoint: &ravenv1alpha1.Endpoint{
+							NodeName: "gateway-node",
+						},
+					},
+				},
+			},
+			deleteGateway: &ravenv1alpha1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cloud-nodepool",
+					Labels: map[string]string{
+						ravenServerLabelKey: ravenServerLabelValue,
+					},
+				},
+				Spec: ravenv1alpha1.GatewaySpec{},
+				Status: ravenv1alpha1.GatewayStatus{
+					ActiveEndpoint: &ravenv1alpha1.Endpoint{
+						NodeName: "gateway-node",
+					},
+				},
+			},
+			expect: map[string]string{
+				dnscontroller.RavenAgentPodLabelKey: dnscontroller.RavenAgentPodLabelValue,
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeServiceController(tt.kubeClient, tt.ravenClient, tt.services, tt.configmap, tt.gateway)
+			fakeDc.deleteGateWay(tt.deleteGateway)
+			go func() {
+				for {
+					time.Sleep(100 * time.Millisecond)
+					if fakeDc.queue.Len() == 0 {
+						fakeDc.queue.ShutDown()
+					}
+				}
+			}()
+			fakeDc.worker()
+			podList, _ := fakeDc.kubeClient.CoreV1().Pods(RavenProxyResourceNamespace).List(context.TODO(), metav1.ListOptions{})
+			get := podList.Items[0]
+			if !reflect.DeepEqual(get.Labels, tt.expect) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect, get.Labels)
+			}
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+
+		})
+	}
+}

--- a/pkg/servicecontroller/informer.go
+++ b/pkg/servicecontroller/informer.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicecontroller
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	ravenv1alpha1 "github.com/openyurtio/raven-controller-manager/pkg/ravencontroller/apis/raven/v1alpha1"
+	racenclient "github.com/openyurtio/raven-controller-manager/pkg/ravencontroller/client/clientset/versioned"
+	raveninformers "github.com/openyurtio/raven-controller-manager/pkg/ravencontroller/client/informers/externalversions"
+	ravenv1aplph1informers "github.com/openyurtio/raven-controller-manager/pkg/ravencontroller/client/informers/externalversions/raven/v1alpha1"
+)
+
+func RegisterRavenInformersForService(ravenInformerFactory raveninformers.SharedInformerFactory) {
+	//register filtered gateway informers
+	ravenInformerFactory.InformerFor(&ravenv1alpha1.Gateway{}, newGatewayInformer)
+
+}
+
+func newGatewayInformer(client racenclient.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	tweakListOptions := func(options *metav1.ListOptions) {
+		options.LabelSelector = fmt.Sprintf("%v=%v", ravenServerLabelKey, ravenServerLabelValue)
+	}
+	gatewayIndexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	return ravenv1aplph1informers.NewFilteredGatewayInformer(client, resyncPeriod, gatewayIndexers, tweakListOptions)
+}
+
+// RegisterInformersForTunnelServer registers shared informers that tunnel server use.
+func RegisterInformersForService(informerFactory informers.SharedInformerFactory) {
+
+	// register filtered service informers
+	informerFactory.InformerFor(&corev1.Service{}, newServiceInformer)
+
+	// register filtered pod informers
+	informerFactory.InformerFor(&corev1.ConfigMap{}, newConfigMapInformer)
+}
+
+// newServiceInformer creates a shared index informers that returns services related to yurttunnel
+func newServiceInformer(client clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+
+	tweakListOptions := func(options *metav1.ListOptions) {
+		options.LabelSelector = fmt.Sprintf("%v=%v", ravenProxyServiceLabelKey, ravenProxyServiceLabelValue)
+	}
+	serviceIndexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	return coreinformers.NewFilteredServiceInformer(client, RavenProxyResourceNamespace, resyncPeriod, serviceIndexers, tweakListOptions)
+}
+
+// newConfigMapInformer creates a shared index informers that returns only interested configmaps
+func newConfigMapInformer(client clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	selector := fmt.Sprintf("metadata.name=%v", ravenProxyPortConfigMapName)
+	tweakListOptions := func(options *metav1.ListOptions) {
+		options.FieldSelector = selector
+	}
+	configmapIndexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+	return coreinformers.NewFilteredConfigMapInformer(client, RavenProxyResourceNamespace, resyncPeriod, configmapIndexers, tweakListOptions)
+}

--- a/pkg/servicecontroller/service_controller.go
+++ b/pkg/servicecontroller/service_controller.go
@@ -1,0 +1,385 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicecontroller
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"github.com/openyurtio/raven-controller-manager/pkg/dnscontroller"
+	ravenv1alpha1 "github.com/openyurtio/raven-controller-manager/pkg/ravencontroller/apis/raven/v1alpha1"
+	ravenclientset "github.com/openyurtio/raven-controller-manager/pkg/ravencontroller/client/clientset/versioned"
+	raveninformers "github.com/openyurtio/raven-controller-manager/pkg/ravencontroller/client/informers/externalversions"
+	gatewaylisters "github.com/openyurtio/raven-controller-manager/pkg/ravencontroller/client/listers/raven/v1alpha1"
+)
+
+type ServiceController interface {
+	Run(stopCh <-chan struct{})
+}
+
+type serviceController struct {
+	kubeClient            clientset.Interface
+	ravenClient           ravenclientset.Interface
+	sharedInformerFactory informers.SharedInformerFactory
+	ravenInformerFactory  raveninformers.SharedInformerFactory
+	queue                 workqueue.RateLimitingInterface
+
+	svcSharedInformer  serviceInformer
+	syncPeriod         int
+	listenInsecurePort string
+	listenSecurePort   string
+}
+
+type serviceInformer struct {
+	svcLister corelisters.ServiceLister
+	cmLister  corelisters.ConfigMapLister
+	gwLister  gatewaylisters.GatewayLister
+
+	svcInformerSynced cache.InformerSynced
+	cmInformerSynced  cache.InformerSynced
+	gwInformerSynced  cache.InformerSynced
+}
+
+func NewServiceController(kubeClient clientset.Interface, ravenClient ravenclientset.Interface, syncPeriod int) ServiceController {
+
+	// register k8s cluster resource informer
+	sharedInformerFactory := informers.NewSharedInformerFactory(kubeClient, 24*time.Hour)
+	RegisterInformersForService(sharedInformerFactory)
+
+	//register openyurt cluster resource informer
+	ravenInformerFactory := raveninformers.NewSharedInformerFactory(ravenClient, 24*time.Hour)
+	RegisterRavenInformersForService(ravenInformerFactory)
+
+	sc := &serviceController{
+		kubeClient:            kubeClient,
+		ravenClient:           ravenClient,
+		syncPeriod:            syncPeriod,
+		listenInsecurePort:    InsecurePort,
+		listenSecurePort:      SecurePort,
+		sharedInformerFactory: sharedInformerFactory,
+		ravenInformerFactory:  ravenInformerFactory,
+		queue:                 workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "tunnel-service"),
+	}
+
+	//add event handler for shared informer factory
+	svcInformerFactory := sharedInformerFactory.Core().V1().Services()
+	svcInformer := svcInformerFactory.Informer()
+	svcInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: sc.addService,
+	})
+	sc.svcSharedInformer.svcLister = svcInformerFactory.Lister()
+	sc.svcSharedInformer.svcInformerSynced = svcInformer.HasSynced
+
+	cmInformerFactory := sharedInformerFactory.Core().V1().ConfigMaps()
+	cmInformer := cmInformerFactory.Informer()
+	cmInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    sc.addConfigMap,
+		UpdateFunc: sc.updateConfigMap,
+		DeleteFunc: sc.deleteConfigMap,
+	})
+	sc.svcSharedInformer.cmLister = cmInformerFactory.Lister()
+	sc.svcSharedInformer.cmInformerSynced = cmInformer.HasSynced
+
+	//add event handler for raven informer factory
+	gwInformerFactory := ravenInformerFactory.Raven().V1alpha1().Gateways()
+	gwInformer := gwInformerFactory.Informer()
+	gwInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    sc.addGateWay,
+		UpdateFunc: sc.updateGateWay,
+		DeleteFunc: sc.deleteGateWay,
+	})
+	sc.svcSharedInformer.gwLister = gwInformerFactory.Lister()
+	sc.svcSharedInformer.gwInformerSynced = gwInformer.HasSynced
+
+	// override syncPeriod when the specified value is too small
+	if sc.syncPeriod < MinSyncPeriod {
+		sc.syncPeriod = MinSyncPeriod
+	}
+
+	return sc
+}
+
+func (sc *serviceController) Run(stopCh <-chan struct{}) {
+	electionChecker := leaderelection.NewLeaderHealthzAdaptor(time.Second * 30)
+	id, err := os.Hostname()
+	if err != nil {
+		klog.Fatalf("failed to get hostname, %v", err)
+	}
+	resourceLock, err := resourcelock.New("leases", metav1.NamespaceSystem, "raven-svc-controller",
+		sc.kubeClient.CoreV1(),
+		sc.kubeClient.CoordinationV1(),
+		resourcelock.ResourceLockConfig{
+			Identity: id + "_" + string(uuid.NewUUID()),
+		})
+	if err != nil {
+		klog.Fatalf("error creating raven-svc-controller resource lock, %v", err)
+	}
+	leaderelection.RunOrDie(context.Background(), leaderelection.LeaderElectionConfig{
+		Lock:          resourceLock,
+		LeaseDuration: metav1.Duration{Duration: time.Second * time.Duration(15)}.Duration,
+		RenewDeadline: metav1.Duration{Duration: time.Second * time.Duration(10)}.Duration,
+		RetryPeriod:   metav1.Duration{Duration: time.Second * time.Duration(2)}.Duration,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				klog.V(3).Infoln("raven service controller start to running")
+				sc.run(stopCh)
+			},
+			OnStoppedLeading: func() {
+				klog.Fatalf("leader election has stopped")
+			},
+		},
+		WatchDog: electionChecker,
+		Name:     "raven-svc-controller",
+	})
+	panic("unreachable")
+}
+
+func (sc *serviceController) run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer sc.queue.ShutDown()
+
+	klog.Infof("starting raven service controller")
+	defer klog.Infof("shutting down raven service controller")
+
+	sc.sharedInformerFactory.Start(stopCh)
+	sc.ravenInformerFactory.Start(stopCh)
+	if !cache.WaitForNamedCacheSync("raven-service-controller",
+		stopCh,
+		sc.svcSharedInformer.svcInformerSynced,
+		sc.svcSharedInformer.cmInformerSynced,
+		sc.svcSharedInformer.gwInformerSynced,
+	) {
+		return
+	}
+
+	go wait.Until(sc.worker, time.Second, stopCh)
+
+	go wait.Until(sc.syncRavenServiceAsWhole, time.Duration(sc.syncPeriod)*time.Second, stopCh)
+
+	go wait.Until(sc.syncGateWayRavenAgent, time.Duration(sc.syncPeriod)*time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (sc *serviceController) enqueue(eventType EventType, obj interface{}) {
+	ele := &Event{
+		Type: eventType,
+		Obj:  obj,
+	}
+	sc.queue.Add(ele)
+}
+
+func (sc *serviceController) worker() {
+	for sc.processNextWorkItem() {
+	}
+}
+
+func (sc *serviceController) processNextWorkItem() bool {
+	event, quit := sc.queue.Get()
+	if quit {
+		return false
+	}
+	defer sc.queue.Done(event)
+
+	err := sc.dispatch(event.(*Event))
+	sc.handleErr(err, event)
+	return true
+}
+
+func (sc *serviceController) dispatch(event *Event) error {
+	switch event.Type {
+	case ServiceAdd:
+		return sc.onServiceAdd(event.Obj.(*corev1.Service))
+	case ConfigMapAdd:
+		return sc.onConfigMapAdd(event.Obj.(*corev1.ConfigMap))
+	case ConfigMapUpdate:
+		return sc.onConfigMapUpdate(event.Obj.(*corev1.ConfigMap))
+	case ConfigMapDelete:
+		return sc.onConfigMapDelete(event.Obj.(*corev1.ConfigMap))
+	case GatewayAdd:
+		return sc.onGatewayAdd(event.Obj.(*ravenv1alpha1.Gateway))
+	case GatewayUpdate:
+		return sc.onGatewayUpdate(event.Obj.(*ravenv1alpha1.Gateway))
+	case GatewayDelete:
+		return sc.onGatewayDelete(event.Obj.(*ravenv1alpha1.Gateway))
+	default:
+		return nil
+	}
+}
+
+func (sc *serviceController) handleErr(err error, event interface{}) {
+	if err == nil {
+		sc.queue.Forget(event)
+		return
+	}
+
+	if sc.queue.NumRequeues(event) < MaxRetries {
+		klog.Infof("error syncing event %v: %v", event, err)
+		sc.queue.AddRateLimited(event)
+		return
+	}
+	utilruntime.HandleError(err)
+	klog.Infof("dropping event %q out of the queue: %v", event, err)
+	sc.queue.Forget(event)
+}
+
+func (sc *serviceController) syncRavenServiceAsWhole() {
+	klog.V(2).Info("start sync raven server service as whole")
+	svc, err := sc.getRavenProxyInternalService()
+	if err != nil {
+		klog.Errorf("failed to sync raven server internal service, %w", err)
+		return
+	}
+
+	cm, err := sc.svcSharedInformer.cmLister.ConfigMaps(RavenProxyResourceNamespace).Get(ravenProxyPortConfigMapName)
+	if err != nil {
+		klog.Errorf("failed to get configmap %v/%v, when sync raven server internal service: %w", RavenProxyResourceNamespace, ravenProxyPortConfigMapName, err)
+		return
+	}
+
+	portsMap := getProxyPortsMap(cm, sc.listenInsecurePort, sc.listenSecurePort)
+	if err = sc.updateRavenService(svc, portsMap); err != nil {
+		klog.Errorf("failed to sync raven server internal service, %w", err)
+	}
+}
+
+func (sc *serviceController) getRavenProxyInternalService() (*corev1.Service, error) {
+	svc, err := sc.svcSharedInformer.svcLister.Services(RavenProxyResourceNamespace).Get(RavenProxyInternalServiceName)
+	if err != nil {
+		return &corev1.Service{}, err
+	}
+	return svc, nil
+}
+
+func (sc *serviceController) updateRavenService(svc *corev1.Service, portsMap map[string]string) error {
+	//record current service ports information
+	ravenServicePortMap := make(map[string]corev1.ServicePort, len(svc.Spec.Ports))
+	for _, svcPort := range svc.Spec.Ports {
+		portKey := fmt.Sprintf("%s:%d", svcPort.Protocol, svcPort.Port)
+		ravenServicePortMap[portKey] = svcPort
+	}
+
+	//record new service ports information
+	ServicePortMap := make(map[string]corev1.ServicePort, len(portsMap))
+	for port, dstPort := range portsMap {
+		portName := fmt.Sprintf("%s-%s", RavenExtendedPort, port)
+		portInt, err := strconv.ParseInt(port, 10, 32)
+		if err != nil {
+			klog.Errorf("failed to parse port, %v", err)
+			continue
+		}
+		targetPortInt, err := strconv.Atoi(dstPort)
+		if err != nil {
+			klog.Errorf("failed to parse target port, %v", err)
+			continue
+		}
+		portKey := fmt.Sprintf("%s:%s", corev1.ProtocolTCP, port)
+		ServicePortMap[portKey] = corev1.ServicePort{
+			Name:       portName,
+			Port:       int32(portInt),
+			Protocol:   corev1.ProtocolTCP,
+			TargetPort: intstr.FromInt(targetPortInt),
+		}
+	}
+
+	isChanged, svcPortsRecord := updateServicePortsRecord(ravenServicePortMap, ServicePortMap)
+	if isChanged {
+		svc.Spec.Ports = svcPortsRecord
+		_, err := sc.kubeClient.CoreV1().Services(RavenProxyResourceNamespace).
+			Update(context.Background(), svc, metav1.UpdateOptions{})
+		if err != nil {
+			klog.Errorf("failed to sync and update raven server service, %v", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (sc *serviceController) syncGateWayRavenAgent() {
+	klog.V(2).Info("start sync gateway raven agent as whole")
+	cloudGateway, err := sc.svcSharedInformer.gwLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to sync gateway raven agent as whole, %w", err)
+		return
+	}
+	if len(cloudGateway) < 1 || cloudGateway[0].Status.ActiveEndpoint == nil {
+		klog.Errorln("there are no gateway in cloud nodepool")
+		return
+	}
+
+	err = sc.managerGatewayRavenAgent(cloudGateway[0].Status.ActiveEndpoint.NodeName)
+	if err != nil {
+		klog.Errorf("failed to manager gateway raven agent in node %s, %s", cloudGateway[0].Status.ActiveEndpoint.NodeName, err)
+	}
+}
+
+func (sc *serviceController) managerGatewayRavenAgent(gateway string) error {
+	options := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", dnscontroller.RavenAgentPodLabelKey, dnscontroller.RavenAgentPodLabelValue),
+	}
+	ravenAgents, err := sc.kubeClient.CoreV1().Pods(RavenProxyResourceNamespace).List(context.TODO(), options)
+	if err != nil {
+		klog.Errorf("failed to get gateway raven agent, %w", err)
+		return err
+	}
+
+	for _, ravenAgent := range ravenAgents.Items {
+		if len(ravenAgent.Spec.NodeName) < 1 {
+			continue
+		}
+
+		isChanged := false
+		if ravenAgent.Spec.NodeName == gateway {
+			ravenAgent.Labels[ravenServerLabelKey] = ravenServerLabelValue
+			isChanged = true
+		} else {
+			_, ok := ravenAgent.Labels[ravenServerLabelKey]
+			if ok {
+				delete(ravenAgent.Labels, ravenServerLabelKey)
+				isChanged = true
+			}
+		}
+
+		if isChanged {
+			_, err = sc.kubeClient.CoreV1().Pods(RavenProxyResourceNamespace).Update(context.TODO(), &ravenAgent, metav1.UpdateOptions{})
+			if err != nil {
+				klog.Errorf("failed to update gateway raven agent, %w", err)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/servicecontroller/service_controller_test.go
+++ b/pkg/servicecontroller/service_controller_test.go
@@ -1,0 +1,1006 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicecontroller
+
+import (
+	"context"
+	"fmt"
+	"github.com/openyurtio/raven-controller-manager/pkg/dnscontroller"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/informers"
+	client "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/util/workqueue"
+
+	ravenv1alpha1 "github.com/openyurtio/raven-controller-manager/pkg/ravencontroller/apis/raven/v1alpha1"
+	ravenClientset "github.com/openyurtio/raven-controller-manager/pkg/ravencontroller/client/clientset/versioned"
+	fakeRavenClientset "github.com/openyurtio/raven-controller-manager/pkg/ravencontroller/client/clientset/versioned/fake"
+	raveninformers "github.com/openyurtio/raven-controller-manager/pkg/ravencontroller/client/informers/externalversions"
+)
+
+const (
+	failed  = "\u2717"
+	succeed = "\u2713"
+)
+
+func newFakeServiceController(fakeKubeClient client.Interface, fakeRavenClient ravenClientset.Interface, services []*corev1.Service, configmaps []*corev1.ConfigMap, gateways []*ravenv1alpha1.Gateway) *serviceController {
+
+	sharedInformerFactory := informers.NewSharedInformerFactory(fakeKubeClient, 24*time.Hour)
+	RegisterInformersForService(sharedInformerFactory)
+
+	ravenInformerFactory := raveninformers.NewSharedInformerFactory(fakeRavenClient, 24*time.Hour)
+	RegisterRavenInformersForService(ravenInformerFactory)
+
+	sc := &serviceController{
+		kubeClient:            fakeKubeClient,
+		ravenClient:           fakeRavenClient,
+		queue:                 workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "tunnel-service"),
+		listenInsecurePort:    InsecurePort,
+		listenSecurePort:      SecurePort,
+		sharedInformerFactory: sharedInformerFactory,
+		ravenInformerFactory:  ravenInformerFactory,
+		syncPeriod:            60,
+	}
+
+	svcInformerFactory := sharedInformerFactory.Core().V1().Services()
+	svcInformer := svcInformerFactory.Informer()
+	sc.svcSharedInformer.svcLister = svcInformerFactory.Lister()
+	sc.svcSharedInformer.svcInformerSynced = svcInformer.HasSynced
+
+	cmInformerFactory := sharedInformerFactory.Core().V1().ConfigMaps()
+	cmInformer := cmInformerFactory.Informer()
+	sc.svcSharedInformer.cmLister = cmInformerFactory.Lister()
+	sc.svcSharedInformer.cmInformerSynced = cmInformer.HasSynced
+
+	//add event handler for raven informer factory
+	gwInformerFactory := ravenInformerFactory.Raven().V1alpha1().Gateways()
+	gwInformer := gwInformerFactory.Informer()
+	sc.svcSharedInformer.gwLister = gwInformerFactory.Lister()
+	sc.svcSharedInformer.gwInformerSynced = gwInformer.HasSynced
+
+	svcIndexer := svcInformer.GetIndexer()
+	for _, svc := range services {
+		if svcIndexer.Add(svc) != nil {
+			continue
+		}
+	}
+	cmIndexer := cmInformer.GetIndexer()
+	for _, cm := range configmaps {
+		if cmIndexer.Add(cm) != nil {
+			continue
+		}
+	}
+	gwIndexer := gwInformer.GetIndexer()
+	for _, gw := range gateways {
+		if gwIndexer.Add(gw) != nil {
+			continue
+		}
+	}
+
+	// override syncPeriod when the specified value is too small
+	if sc.syncPeriod < MinSyncPeriod {
+		sc.syncPeriod = MinSyncPeriod
+	}
+
+	return sc
+}
+
+func getProxyPortService(client client.Interface) (svc *corev1.Service, err error) {
+	return client.CoreV1().Services(RavenProxyResourceNamespace).
+		Get(context.TODO(), RavenProxyInternalServiceName, metav1.GetOptions{})
+}
+
+func getRavenAgent(client client.Interface, name string) (pod *corev1.Pod, err error) {
+	return client.CoreV1().Pods(RavenProxyResourceNamespace).
+		Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func TestServiceController_GetRavenProxyInternalService(t *testing.T) {
+	testcases := []struct {
+		desc        string
+		kubeClient  client.Interface
+		ravenClient ravenClientset.Interface
+		gateway     []*ravenv1alpha1.Gateway
+		services    []*corev1.Service
+		configmap   []*corev1.ConfigMap
+		expect      *corev1.Service
+	}{
+		{
+			desc:        fmt.Sprintf("there is no services %s/%s", RavenProxyResourceNamespace, RavenProxyInternalServiceName),
+			kubeClient:  fake.NewSimpleClientset(),
+			ravenClient: fakeRavenClientset.NewSimpleClientset(),
+			services:    []*corev1.Service{},
+			configmap:   []*corev1.ConfigMap{},
+			gateway:     []*ravenv1alpha1.Gateway{},
+			expect:      &corev1.Service{},
+		},
+		{
+			desc:        fmt.Sprintf("there is a services %s/%s", RavenProxyResourceNamespace, RavenProxyInternalServiceName),
+			kubeClient:  fake.NewSimpleClientset(),
+			ravenClient: fakeRavenClientset.NewSimpleClientset(),
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			configmap: []*corev1.ConfigMap{},
+			gateway:   []*ravenv1alpha1.Gateway{},
+			expect: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      RavenProxyInternalServiceName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "172.168.0.1",
+					Ports:     []corev1.ServicePort{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeServiceController(tt.kubeClient, tt.ravenClient, tt.services, tt.configmap, tt.gateway)
+			get, err := fakeDc.getRavenProxyInternalService()
+			if err != nil {
+				t.Logf("failed to get service %s, %v", RavenProxyInternalServiceName, err)
+			}
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect, get)
+			}
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}
+
+func TestServiceController_UpdateRavenService(t *testing.T) {
+
+	testcases := []struct {
+		desc        string
+		kubeClient  client.Interface
+		ravenClient ravenClientset.Interface
+		gateway     []*ravenv1alpha1.Gateway
+		services    []*corev1.Service
+		configmap   []*corev1.ConfigMap
+		ports       map[string]string
+		expect      *corev1.Service
+	}{
+		{
+			desc: fmt.Sprintf("add proxy port and update the services %s/%s", RavenProxyResourceNamespace, RavenProxyInternalServiceName),
+			kubeClient: fake.NewSimpleClientset(
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http",
+								Port:       10255,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10264),
+							},
+							{
+								Name:       "https",
+								Port:       10250,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10263),
+							},
+						},
+					},
+				},
+			),
+			ravenClient: fakeRavenClientset.NewSimpleClientset(),
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http",
+								Port:       10255,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10264),
+							},
+							{
+								Name:       "https",
+								Port:       10250,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10263),
+							},
+						},
+					},
+				},
+			},
+			configmap: []*corev1.ConfigMap{},
+			gateway:   []*ravenv1alpha1.Gateway{},
+			ports: map[string]string{
+				"9100": "10263",
+				"9445": "10264",
+			},
+			expect: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      RavenProxyInternalServiceName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "172.168.0.1",
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "extend-9100",
+							Port:       9100,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10263),
+						},
+						{
+							Name:       "extend-9445",
+							Port:       9445,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10264),
+						},
+						{
+							Name:       "http",
+							Port:       10255,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10264),
+						},
+						{
+							Name:       "https",
+							Port:       10250,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10263),
+						},
+					},
+				},
+			},
+		},
+
+		{
+			desc: fmt.Sprintf("update proxy port and update the services %s/%s", RavenProxyResourceNamespace, RavenProxyInternalServiceName),
+			kubeClient: fake.NewSimpleClientset(
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http",
+								Port:       10255,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10264),
+							},
+							{
+								Name:       "https",
+								Port:       10250,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10263),
+							},
+							{
+								Name:       "extend-9100",
+								Port:       9100,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10263),
+							},
+						},
+					},
+				},
+			),
+			ravenClient: fakeRavenClientset.NewSimpleClientset(),
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http",
+								Port:       10255,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10264),
+							},
+							{
+								Name:       "https",
+								Port:       10250,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10263),
+							},
+							{
+								Name:       "extend-9100",
+								Port:       9100,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10263),
+							},
+						},
+					},
+				},
+			},
+			configmap: []*corev1.ConfigMap{},
+			gateway:   []*ravenv1alpha1.Gateway{},
+			ports: map[string]string{
+				"9100": "10264",
+			},
+			expect: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      RavenProxyInternalServiceName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "172.168.0.1",
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "extend-9100",
+							Port:       9100,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10264),
+						},
+						{
+							Name:       "http",
+							Port:       10255,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10264),
+						},
+						{
+							Name:       "https",
+							Port:       10250,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10263),
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: fmt.Sprintf("delete proxy port and update the services %s/%s", RavenProxyResourceNamespace, RavenProxyInternalServiceName),
+			kubeClient: fake.NewSimpleClientset(
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http",
+								Port:       10255,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10264),
+							},
+							{
+								Name:       "https",
+								Port:       10250,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10263),
+							},
+							{
+								Name:       "extend-9100",
+								Port:       9100,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10263),
+							},
+						},
+					},
+				},
+			),
+			ravenClient: fakeRavenClientset.NewSimpleClientset(),
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http",
+								Port:       10255,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10264),
+							},
+							{
+								Name:       "https",
+								Port:       10250,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10263),
+							},
+							{
+								Name:       "extend-9100",
+								Port:       9100,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10263),
+							},
+						},
+					},
+				},
+			},
+			configmap: []*corev1.ConfigMap{},
+			ports:     map[string]string{},
+			expect: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      RavenProxyInternalServiceName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "172.168.0.1",
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       10255,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10264),
+						},
+						{
+							Name:       "https",
+							Port:       10250,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10263),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeServiceController(tt.kubeClient, tt.ravenClient, tt.services, tt.configmap, tt.gateway)
+			svc, _ := getProxyPortService(fakeDc.kubeClient)
+			err := fakeDc.updateRavenService(svc, tt.ports)
+			if err != nil {
+				t.Logf("failed to update dns records %v", err)
+			}
+			get, _ := getProxyPortService(tt.kubeClient)
+
+			sort.Slice(get.Spec.Ports, func(i, j int) bool {
+				return get.Spec.Ports[i].Port >= get.Spec.Ports[j].Port
+			})
+
+			sort.Slice(tt.expect.Spec.Ports, func(i, j int) bool {
+				return tt.expect.Spec.Ports[i].Port >= tt.expect.Spec.Ports[j].Port
+			})
+
+			if !reflect.DeepEqual(get.Spec.Ports, tt.expect.Spec.Ports) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect.Spec.Ports, get.Spec.Ports)
+			}
+
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}
+
+func TestServiceController_SyncRavenServiceAsWhole(t *testing.T) {
+	testcases := []struct {
+		desc        string
+		kubeClient  client.Interface
+		ravenClient ravenClientset.Interface
+		gateway     []*ravenv1alpha1.Gateway
+		services    []*corev1.Service
+		configmap   []*corev1.ConfigMap
+		ports       map[string]string
+		expect      *corev1.Service
+	}{
+		{
+			desc: fmt.Sprintf("sync raven service %s/%s with add proxy port", RavenProxyResourceNamespace, RavenProxyInternalServiceName),
+			kubeClient: fake.NewSimpleClientset(
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenProxyPortConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						"localhost-proxy-ports": "10266, 10267",
+						"http-proxy-ports":      "9445",
+						"https-proxy-ports":     "9100",
+					},
+				},
+			),
+			ravenClient: fakeRavenClientset.NewSimpleClientset(),
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			configmap: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenProxyPortConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						"localhost-proxy-ports": "10266, 10267",
+						"http-proxy-ports":      "9445",
+						"https-proxy-ports":     "9100",
+					},
+				},
+			},
+			gateway: []*ravenv1alpha1.Gateway{},
+			expect: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      RavenProxyInternalServiceName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "172.168.0.1",
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "extend-9100",
+							Port:       9100,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10263),
+						},
+						{
+							Name:       "extend-9445",
+							Port:       9445,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10264),
+						},
+					},
+				},
+			},
+		},
+
+		{
+			desc: fmt.Sprintf("sync raven service %s/%s with update proxy port", RavenProxyResourceNamespace, RavenProxyInternalServiceName),
+			kubeClient: fake.NewSimpleClientset(
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "extend-9100",
+								Port:       9100,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10263),
+							},
+							{
+								Name:       "extend-9445",
+								Port:       9445,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10264),
+							},
+						},
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenProxyPortConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						"localhost-proxy-ports": "10266, 10267",
+						"http-proxy-ports":      "9100",
+						"https-proxy-ports":     "9445",
+					},
+				},
+			),
+			ravenClient: fakeRavenClientset.NewSimpleClientset(),
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports:     []corev1.ServicePort{},
+					},
+				},
+			},
+			configmap: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenProxyPortConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						"localhost-proxy-ports": "10266, 10267",
+						"http-proxy-ports":      "9100",
+						"https-proxy-ports":     "9445",
+					},
+				},
+			},
+			gateway: []*ravenv1alpha1.Gateway{},
+			expect: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      RavenProxyInternalServiceName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "172.168.0.1",
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "extend-9100",
+							Port:       9100,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10264),
+						},
+						{
+							Name:       "extend-9445",
+							Port:       9445,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt(10263),
+						},
+					},
+				},
+			},
+		},
+
+		{
+			desc: fmt.Sprintf("sync raven service %s/%s with delete proxy port", RavenProxyResourceNamespace, RavenProxyInternalServiceName),
+			kubeClient: fake.NewSimpleClientset(
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "extend-9100",
+								Port:       9100,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10263),
+							},
+							{
+								Name:       "extend-9445",
+								Port:       9445,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10264),
+							},
+						},
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenProxyPortConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						"localhost-proxy-ports": "10266, 10267",
+						"http-proxy-ports":      "",
+						"https-proxy-ports":     "",
+					},
+				},
+			),
+			ravenClient: fakeRavenClientset.NewSimpleClientset(),
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      RavenProxyInternalServiceName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "172.168.0.1",
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "extend-9100",
+								Port:       9100,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10263),
+							},
+							{
+								Name:       "extend-9445",
+								Port:       9445,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt(10264),
+							},
+						},
+					},
+				},
+			},
+			configmap: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      ravenProxyPortConfigMapName,
+						Namespace: RavenProxyResourceNamespace,
+					},
+					Data: map[string]string{
+						"localhost-proxy-ports": "10266, 10267",
+						"http-proxy-ports":      "",
+						"https-proxy-ports":     "",
+					},
+				},
+			},
+			gateway: []*ravenv1alpha1.Gateway{},
+			expect: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      RavenProxyInternalServiceName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "172.168.0.1",
+					Ports:     []corev1.ServicePort{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeServiceController(tt.kubeClient, tt.ravenClient, tt.services, tt.configmap, tt.gateway)
+			fakeDc.syncRavenServiceAsWhole()
+			get, _ := getProxyPortService(fakeDc.kubeClient)
+
+			sort.Slice(get.Spec.Ports, func(i, j int) bool {
+				return get.Spec.Ports[i].Port < get.Spec.Ports[j].Port
+			})
+
+			sort.Slice(tt.expect.Spec.Ports, func(i, j int) bool {
+				return tt.expect.Spec.Ports[i].Port < tt.expect.Spec.Ports[j].Port
+			})
+
+			if !reflect.DeepEqual(get.Spec.Ports, tt.expect.Spec.Ports) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect.Spec.Ports, get.Spec.Ports)
+			}
+
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}
+
+func TestServiceController_SyncGatewayRavenAgent(t *testing.T) {
+	testcases := []struct {
+		desc        string
+		kubeClient  client.Interface
+		ravenClient ravenClientset.Interface
+		gateway     []*ravenv1alpha1.Gateway
+		services    []*corev1.Service
+		configmap   []*corev1.ConfigMap
+		expect      map[string]map[string]string
+	}{
+		{
+			desc: "sync gateway raven agent pod",
+			kubeClient: fake.NewSimpleClientset(
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod-1",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							dnscontroller.RavenAgentPodLabelKey: dnscontroller.RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "gateway-node",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod-2",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							dnscontroller.RavenAgentPodLabelKey: dnscontroller.RavenAgentPodLabelValue,
+							ravenServerLabelKey:                 ravenServerLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "cloud-node-1",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod-3",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							dnscontroller.RavenAgentPodLabelKey: dnscontroller.RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "cloud-node-2",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				}),
+			ravenClient: fakeRavenClientset.NewSimpleClientset(),
+			gateway: []*ravenv1alpha1.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cloud-nodepool",
+						Labels: map[string]string{
+							ravenServerLabelKey: ravenServerLabelValue,
+						},
+					},
+					Spec: ravenv1alpha1.GatewaySpec{},
+					Status: ravenv1alpha1.GatewayStatus{
+						ActiveEndpoint: &ravenv1alpha1.Endpoint{
+							NodeName: "gateway-node",
+						},
+					},
+				},
+			},
+			services:  []*corev1.Service{},
+			configmap: []*corev1.ConfigMap{},
+			expect: map[string]map[string]string{
+				"raven-pod-1": {
+					dnscontroller.RavenAgentPodLabelKey: dnscontroller.RavenAgentPodLabelValue,
+					ravenServerLabelKey:                 ravenServerLabelValue,
+				},
+				"raven-pod-2": {
+					dnscontroller.RavenAgentPodLabelKey: dnscontroller.RavenAgentPodLabelValue,
+				},
+				"raven-pod-3": {
+					dnscontroller.RavenAgentPodLabelKey: dnscontroller.RavenAgentPodLabelValue,
+				},
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeServiceController(tt.kubeClient, tt.ravenClient, tt.services, tt.configmap, tt.gateway)
+			fakeDc.syncGateWayRavenAgent()
+
+			pods, err := fakeDc.kubeClient.CoreV1().Pods(RavenProxyResourceNamespace).List(context.TODO(), metav1.ListOptions{})
+			if err != nil {
+				t.Logf("failed to list raven agent pod")
+			}
+
+			for _, get := range pods.Items {
+				if !reflect.DeepEqual(get.Labels, tt.expect[get.Name]) {
+					t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect, get)
+				}
+				t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect[get.Name], get.Labels)
+			}
+		})
+	}
+}
+
+func TestServiceController_ManagerGatewayRavenAgent(t *testing.T) {
+	testcases := []struct {
+		desc            string
+		kubeClient      client.Interface
+		ravenClient     ravenClientset.Interface
+		gateway         []*ravenv1alpha1.Gateway
+		services        []*corev1.Service
+		configmap       []*corev1.ConfigMap
+		gatewayNodeName string
+		expect          map[string]string
+	}{
+		{
+			desc: "select gateway raven agent pod",
+			kubeClient: fake.NewSimpleClientset(
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod-1",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							dnscontroller.RavenAgentPodLabelKey: dnscontroller.RavenAgentPodLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "gateway-node",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				}),
+			gatewayNodeName: "gateway-node",
+			gateway:         []*ravenv1alpha1.Gateway{},
+			services:        []*corev1.Service{},
+			configmap:       []*corev1.ConfigMap{},
+			expect: map[string]string{
+				dnscontroller.RavenAgentPodLabelKey: dnscontroller.RavenAgentPodLabelValue,
+				ravenServerLabelKey:                 ravenServerLabelValue,
+			},
+		},
+
+		{
+			desc: "update normal raven agent pod",
+			kubeClient: fake.NewSimpleClientset(
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "raven-pod-1",
+						Namespace: RavenProxyResourceNamespace,
+						Labels: map[string]string{
+							dnscontroller.RavenAgentPodLabelKey: dnscontroller.RavenAgentPodLabelValue,
+							ravenServerLabelKey:                 ravenServerLabelValue,
+						},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "normal-cloud-node",
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				}),
+			gatewayNodeName: "gateway-node",
+			gateway:         []*ravenv1alpha1.Gateway{},
+			services:        []*corev1.Service{},
+			configmap:       []*corev1.ConfigMap{},
+			expect: map[string]string{
+				dnscontroller.RavenAgentPodLabelKey: dnscontroller.RavenAgentPodLabelValue,
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			fakeDc := newFakeServiceController(tt.kubeClient, tt.ravenClient, tt.services, tt.configmap, tt.gateway)
+			err := fakeDc.managerGatewayRavenAgent(tt.gatewayNodeName)
+			if err != nil {
+				t.Logf("failed to get raven agent in node %s", tt.gatewayNodeName)
+			}
+			get, _ := getRavenAgent(fakeDc.kubeClient, "raven-pod-1")
+
+			if !reflect.DeepEqual(get.Labels, tt.expect) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect, get.Labels)
+			}
+
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}

--- a/pkg/servicecontroller/util.go
+++ b/pkg/servicecontroller/util.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicecontroller
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/openyurtio/raven-controller-manager/pkg/projectinfo"
+)
+
+// GetRavenProxyPortConfigMapName get the configmap named yurt-raven-server-cfg
+func GetRavenProxyPortConfigMapName() string {
+	return fmt.Sprintf(RavenProxyDNATConfigMapName,
+		strings.TrimRightFunc(projectinfo.GetProjectPrefix(), func(c rune) bool { return c == '-' }))
+}
+
+// GetRavenServerLabelKey get the label key of raven service : yurt-app
+func GetRavenServerLabelKey() string {
+	return fmt.Sprintf(RavenServerLabelKey,
+		strings.TrimRightFunc(projectinfo.GetProjectPrefix(), func(c rune) bool { return c == '-' }))
+}
+
+// GetRavenServerLabelValue get the label key of raven service : yurt-tunnel-server
+func GetRavenServerLabelValue() string {
+	return fmt.Sprintf(RavenServerLabelValue,
+		strings.TrimRightFunc(projectinfo.GetProjectPrefix(), func(c rune) bool { return c == '-' }))
+}
+
+// GetProxyPortsAndMappings get proxy ports and port mappings from specified configmap
+func getProxyPortsMap(cm *corev1.ConfigMap, insecureListenPort, secureListenPort string) map[string]string {
+	portsMap := make(map[string]string)
+
+	// resolve http-proxy-port field
+	for _, port := range processPort(cm.Data[RavenServerHTTPProxyPorts]) {
+		portsMap[port] = insecureListenPort
+	}
+
+	// resolve https-proxy-port field
+	for _, port := range processPort(cm.Data[RavenServerHTTPSProxyPorts]) {
+		portsMap[port] = secureListenPort
+	}
+
+	// cleanup 10250/10255 mappings
+	delete(portsMap, KubeletHTTPSPort)
+	delete(portsMap, KubeletHTTPPort)
+
+	return portsMap
+}
+
+// processPort parse the specified ports setting and return ports slice.
+func processPort(portsStr string) []string {
+	ports := make([]string, 0)
+	if len(strings.TrimSpace(portsStr)) == 0 {
+		return ports
+	}
+
+	portsSubStr := strings.Split(portsStr, ",")
+	for _, port := range portsSubStr {
+		proxyPort := strings.TrimSpace(port)
+		if len(proxyPort) != 0 {
+			portInt, err := strconv.Atoi(proxyPort)
+			if err != nil {
+				klog.Errorf("failed to parse port %s, %v", port, err)
+				continue
+			} else if portInt < MinPort || portInt > MaxPort {
+				klog.Errorf("port %s is not invalid port(should be range 1~65535)", port)
+				continue
+			}
+
+			ports = append(ports, proxyPort)
+		}
+	}
+	return ports
+}
+
+func updateServicePortsRecord(oldServicePortMap, newServicePortMap map[string]corev1.ServicePort) (bool, []corev1.ServicePort) {
+	var isChanged = false
+	svcPortsRecord := make([]corev1.ServicePort, 0)
+
+	equal := func(p1, p2 *corev1.ServicePort) bool {
+		if p1.Name != p2.Name {
+			return false
+		}
+		if p1.Port != p2.Port {
+			return false
+		}
+		if p1.Protocol != p2.Protocol {
+			return false
+		}
+		if p1.TargetPort != p2.TargetPort {
+			return false
+		}
+		return true
+	}
+
+	for portKey, newSvcPort := range newServicePortMap {
+		oldSvcPort, ok := oldServicePortMap[portKey]
+		if !ok {
+			oldServicePortMap[portKey] = newSvcPort
+			isChanged = true
+			continue
+		}
+		if !equal(&oldSvcPort, &newSvcPort) {
+			oldServicePortMap[portKey] = newSvcPort
+			isChanged = true
+			continue
+		}
+	}
+
+	for portKey, servicePort := range oldServicePortMap {
+		_, ok := newServicePortMap[portKey]
+		if !ok &&
+			strings.HasPrefix(portKey, string(corev1.ProtocolTCP)) &&
+			strings.HasPrefix(servicePort.Name, RavenExtendedPort) {
+			isChanged = true
+			continue
+		}
+		svcPortsRecord = append(svcPortsRecord, servicePort)
+	}
+	return isChanged, svcPortsRecord
+}

--- a/pkg/servicecontroller/util_test.go
+++ b/pkg/servicecontroller/util_test.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicecontroller
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func Test_GetProxyPortsMap(t *testing.T) {
+	testcases := []struct {
+		desc      string
+		configmap *corev1.ConfigMap
+		expect    map[string]string
+	}{
+		{
+			desc: fmt.Sprintf("get proxy port map from configmap %v/%v", RavenProxyResourceNamespace, ravenProxyPortConfigMapName),
+			configmap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ravenProxyPortConfigMapName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Data: map[string]string{
+					"localhost-proxy-ports": "10250, 10255,10266, 10267",
+					"http-proxy-ports":      "9445",
+					"https-proxy-ports":     "9100",
+				},
+			},
+			expect: map[string]string{
+				"9445": InsecurePort,
+				"9100": SecurePort,
+			},
+		},
+
+		{
+			desc: fmt.Sprintf("delete proxy port 10255 and 10250 map from configmap %v/%v", RavenProxyResourceNamespace, ravenProxyPortConfigMapName),
+			configmap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ravenProxyPortConfigMapName,
+					Namespace: RavenProxyResourceNamespace,
+				},
+				Data: map[string]string{
+					"localhost-proxy-ports": "10266, 10267",
+					"http-proxy-ports":      "9445, 10255",
+					"https-proxy-ports":     "9100, 10250",
+				},
+			},
+			expect: map[string]string{
+				"9445": InsecurePort,
+				"9100": SecurePort,
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			get := getProxyPortsMap(tt.configmap, InsecurePort, SecurePort)
+			if !reflect.DeepEqual(get, tt.expect) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect, get)
+			}
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}
+
+func Test_UpdateServicePortsRecord(t *testing.T) {
+	testcases := []struct {
+		desc           string
+		oldServicePort map[string]corev1.ServicePort
+		newServicePort map[string]corev1.ServicePort
+		expect         struct {
+			ports     []corev1.ServicePort
+			isChanged bool
+		}
+	}{
+		{
+			desc:           "add service port",
+			oldServicePort: map[string]corev1.ServicePort{},
+			newServicePort: map[string]corev1.ServicePort{
+				"TCP:9100": {
+					Name:       "extend-9100",
+					Port:       9100,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(10250),
+				},
+			},
+			expect: struct {
+				ports     []corev1.ServicePort
+				isChanged bool
+			}{
+				ports: []corev1.ServicePort{
+					{
+						Name:       "extend-9100",
+						Port:       9100,
+						Protocol:   corev1.ProtocolTCP,
+						TargetPort: intstr.FromInt(10250),
+					},
+				},
+				isChanged: true,
+			},
+		},
+
+		{
+			desc: "update service port",
+			oldServicePort: map[string]corev1.ServicePort{
+				"TCP:9100": {
+					Name:       "extend-9100",
+					Port:       9100,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(10250),
+				},
+			},
+			newServicePort: map[string]corev1.ServicePort{
+				"TCP:9100": {
+					Name:       "extend-9100",
+					Port:       9100,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(10255),
+				},
+			},
+			expect: struct {
+				ports     []corev1.ServicePort
+				isChanged bool
+			}{
+				ports: []corev1.ServicePort{
+					{
+						Name:       "extend-9100",
+						Port:       9100,
+						Protocol:   corev1.ProtocolTCP,
+						TargetPort: intstr.FromInt(10255),
+					},
+				},
+				isChanged: true,
+			},
+		},
+
+		{
+			desc: "update service port",
+			oldServicePort: map[string]corev1.ServicePort{
+				"TCP:9100": {
+					Name:       "extend-9100",
+					Port:       9100,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(10250),
+				},
+			},
+			newServicePort: map[string]corev1.ServicePort{
+				"TCP:9100": {
+					Name:       "extend-9100",
+					Port:       9100,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(10250),
+				},
+			},
+			expect: struct {
+				ports     []corev1.ServicePort
+				isChanged bool
+			}{
+				ports: []corev1.ServicePort{
+					{
+						Name:       "extend-9100",
+						Port:       9100,
+						Protocol:   corev1.ProtocolTCP,
+						TargetPort: intstr.FromInt(10250),
+					},
+				},
+				isChanged: false,
+			},
+		},
+
+		{
+			desc: "delete service port",
+			oldServicePort: map[string]corev1.ServicePort{
+				"TCP:9100": {
+					Name:       "extend-9100",
+					Port:       9100,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(10250),
+				},
+			},
+			newServicePort: map[string]corev1.ServicePort{},
+			expect: struct {
+				ports     []corev1.ServicePort
+				isChanged bool
+			}{
+				ports:     []corev1.ServicePort{},
+				isChanged: true,
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Logf("\tTestCase: %s", tt.desc)
+			isChanged, get := updateServicePortsRecord(tt.oldServicePort, tt.newServicePort)
+			if !reflect.DeepEqual(get, tt.expect.ports) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect.ports, get)
+			}
+
+			if !reflect.DeepEqual(isChanged, tt.expect.isChanged) {
+				t.Fatalf("\t%s\texpect %v, but get %v", failed, tt.expect.isChanged, isChanged)
+			}
+			t.Logf("\t%s\texpect %v, get %v", succeed, tt.expect, get)
+		})
+	}
+}

--- a/pkg/servicecontroller/worker.go
+++ b/pkg/servicecontroller/worker.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2022 The OpenYurt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicecontroller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/openyurtio/raven-controller-manager/pkg/dnscontroller"
+	ravenv1alpha1 "github.com/openyurtio/raven-controller-manager/pkg/ravencontroller/apis/raven/v1alpha1"
+)
+
+func (sc *serviceController) onServiceAdd(svc *corev1.Service) error {
+	cm, err := sc.svcSharedInformer.cmLister.ConfigMaps(RavenProxyResourceNamespace).Get(ravenProxyPortConfigMapName)
+	if err != nil {
+		klog.Errorf("failed to get configmap %v/%v, when sync raven server internal service: %w", RavenProxyResourceNamespace, ravenProxyPortConfigMapName, err)
+		return err
+	}
+
+	_, err = sc.kubeClient.CoreV1().Services(RavenProxyResourceNamespace).Get(context.TODO(), RavenProxyInternalServiceName, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("failed to get service %s/%s, %w", RavenProxyResourceNamespace, RavenProxyInternalServiceName, err)
+		return err
+	}
+
+	portsMap := getProxyPortsMap(cm, sc.listenInsecurePort, sc.listenSecurePort)
+	if err = sc.updateRavenService(svc, portsMap); err != nil {
+		klog.Errorf("failed to sync raven server internal service, %w", err)
+	}
+	return err
+}
+
+func (sc *serviceController) onConfigMapAdd(cm *corev1.ConfigMap) error {
+	svc, err := sc.getRavenProxyInternalService()
+	if err != nil {
+		klog.Errorf("failed to sync raven server internal service, %w", err)
+		return err
+	}
+
+	portsMap := getProxyPortsMap(cm, sc.listenInsecurePort, sc.listenSecurePort)
+	if err = sc.updateRavenService(svc, portsMap); err != nil {
+		klog.Errorf("failed to sync raven server internal service, %w", err)
+	}
+	return err
+}
+
+func (sc *serviceController) onConfigMapUpdate(cm *corev1.ConfigMap) error {
+	svc, err := sc.getRavenProxyInternalService()
+	if err != nil {
+		klog.Errorf("failed to sync raven server internal service, %w", err)
+		return err
+	}
+
+	portsMap := getProxyPortsMap(cm, sc.listenInsecurePort, sc.listenSecurePort)
+	if err = sc.updateRavenService(svc, portsMap); err != nil {
+		klog.Errorf("failed to sync raven server internal service, %w", err)
+	}
+	return err
+}
+
+func (sc *serviceController) onConfigMapDelete(cm *corev1.ConfigMap) error {
+	svc, err := sc.getRavenProxyInternalService()
+	if err != nil {
+		klog.Errorf("failed to sync raven server internal service, %w", err)
+		return err
+	}
+
+	portsMap := make(map[string]string, 0)
+	if err = sc.updateRavenService(svc, portsMap); err != nil {
+		klog.Errorf("failed to sync raven server internal service, %w", err)
+	}
+	return err
+}
+
+func (sc *serviceController) onGatewayAdd(gw *ravenv1alpha1.Gateway) error {
+	return sc.managerRavenServer(gw.Status.ActiveEndpoint.NodeName, true)
+}
+
+func (sc *serviceController) onGatewayUpdate(gw *ravenv1alpha1.Gateway) error {
+	return sc.managerRavenServer(gw.Status.ActiveEndpoint.NodeName, true)
+}
+
+func (sc *serviceController) onGatewayDelete(gw *ravenv1alpha1.Gateway) error {
+	return sc.managerRavenServer(gw.Status.ActiveEndpoint.NodeName, false)
+}
+
+// note: fake clientset cannot simulate the logic of extract object values to match field selectors is not available from within the fake client
+func (sc *serviceController) managerRavenServer(nodeName string, isGateway bool) error {
+	options := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", dnscontroller.RavenAgentPodLabelKey, dnscontroller.RavenAgentPodLabelValue),
+		FieldSelector: fmt.Sprintf("%s=%s", "spec.nodeName", nodeName),
+	}
+	ravenAgents, err := sc.kubeClient.CoreV1().Pods(RavenProxyResourceNamespace).List(context.TODO(), options)
+	if err != nil || len(ravenAgents.Items) < 1 {
+		klog.Errorf("failed to get gateway raven agent, %w", err)
+		return err
+	}
+	var gatewayRavenAgent *corev1.Pod = nil
+	for _, ravenAgent := range ravenAgents.Items {
+		if ravenAgent.Status.Phase == corev1.PodRunning {
+			gatewayRavenAgent = &ravenAgent
+			break
+		}
+	}
+
+	if gatewayRavenAgent == nil {
+		return fmt.Errorf("failed get running raven agent in gateway node %s", nodeName)
+	}
+
+	if isGateway {
+		gatewayRavenAgent.Labels[ravenServerLabelKey] = ravenServerLabelValue
+	} else {
+		_, ok := gatewayRavenAgent.Labels[ravenServerLabelKey]
+		if ok {
+			delete(gatewayRavenAgent.Labels, ravenServerLabelKey)
+		}
+	}
+
+	_, err = sc.kubeClient.CoreV1().Pods(RavenProxyResourceNamespace).Update(context.TODO(), gatewayRavenAgent, metav1.UpdateOptions{})
+	if err != nil {
+		klog.Errorf("failed to update gateway raven agent, %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
1. DNS manager is used to dynamically update dns records by watching raven agent pod. For instance, the access request from cloud to edge will be forwarded to x-raven-internal-service if a raven-agent is deployed on the destination edge node，it is easy to understand that a request will be sent directly to the destionation edge node if there is no a running raven agent.
2. Service manager is used to maintain the port in x-raven-internal-service, and select a raven agent as the backend for both x-raven-internal-service and x-raven-service in cloud gateway node. You need select a gateway in cloud and label it yurt-app: yurt-tunnel-server, service manager will select automatically the raven agent on the gateway node to undertake the forwarding task.